### PR TITLE
feat: adding deployments fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1709,9 +1709,9 @@
       "dev": true
     },
     "dcl-catalyst-commons": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-1.2.4.tgz",
-      "integrity": "sha512-JZmwovrghHddCgNE5zjNM57Hniu7o0KpOQSR4zeElYpIMGptYuIxLdLRwLGdMWOa7ZIcpvvF5T27mkeE/Gxt1Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-1.3.2.tgz",
+      "integrity": "sha512-lTFhf67k76YMysvBJyXYroq0AdVrBJLAbT68IeAfZLuf7ed3QEqLtl95pGSLrniRFwuOjo2xcV7oLrcVFxaqIg==",
       "requires": {
         "@types/isomorphic-fetch": "0.0.35",
         "@types/ms": "^0.7.31",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "abort-controller": "^3.0.0",
     "cids": "^0.8.0",
     "cross-blob": "^1.2.2",
-    "dcl-catalyst-commons": "^1.2.4",
+    "dcl-catalyst-commons": "^1.3.2",
     "dcl-crypto": "^2.1.0",
     "isomorphic-form-data": "^2.0.0",
     "ms": "^2.1.2",

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -1,9 +1,9 @@
 import { EthAddress } from 'dcl-crypto'
-import { Timestamp, Pointer, EntityType, Entity, EntityId, AuditInfo, ServerStatus, ServerName, ContentFileHash, DeploymentHistory, Profile, PartialDeploymentHistory, Fetcher, RequestOptions } from "dcl-catalyst-commons";
+import { Timestamp, Pointer, EntityType, Entity, EntityId, AuditInfo, ServerStatus, ServerName, ContentFileHash, Profile, PartialDeploymentHistory, Fetcher, RequestOptions, LegacyPartialDeploymentHistory, LegacyDeploymentHistory, DeploymentFilters, AvailableContentResult, DeploymentBase, DeploymentWithPointers, DeploymentWithContent, DeploymentWithMetadata, Deployment } from "dcl-catalyst-commons";
 import { CatalystAPI } from "./CatalystAPI";
 import { DeploymentData } from './utils/DeploymentBuilder';
 import { sanitizeUrl } from './utils/Helper';
-import { ContentClient } from './ContentClient';
+import { ContentClient, DeploymentFields } from './ContentClient';
 import { LambdasClient } from './LambdasClient';
 
 export class CatalystClient implements CatalystAPI {
@@ -39,16 +39,28 @@ export class CatalystClient implements CatalystAPI {
         return this.contentClient.fetchAuditInfo(type, id, options)
     }
 
-    fetchFullHistory(query?: { from?: number; to?: number; serverName?: string }, options?: RequestOptions): Promise<DeploymentHistory> {
+    fetchFullHistory(query?: { from?: number; to?: number; serverName?: string }, options?: RequestOptions): Promise<LegacyDeploymentHistory> {
         return this.contentClient.fetchFullHistory(query, options)
     }
 
-    fetchHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName, offset?: number, limit?: number}, options?: RequestOptions): Promise<PartialDeploymentHistory> {
+    fetchHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName, offset?: number, limit?: number}, options?: RequestOptions): Promise<LegacyPartialDeploymentHistory> {
         return this.contentClient.fetchHistory(query, options)
     }
 
     fetchStatus(options?: RequestOptions): Promise<ServerStatus> {
         return this.contentClient.fetchStatus(options)
+    }
+
+    fetchAllDeployments<T extends DeploymentBase = Deployment>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]> {
+        return this.contentClient.fetchAllDeployments(filters, fields, options)
+    }
+
+    fetchLastDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(offset?: number, limit?: number, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<PartialDeploymentHistory<T>> {
+        return this.contentClient.fetchLastDeployments<T>(offset, limit, fields, options)
+    }
+
+    isContentAvailable(cids: string[], options?: RequestOptions): Promise<AvailableContentResult> {
+        return this.contentClient.isContentAvailable(cids, options)
     }
 
     downloadContent(contentHash: ContentFileHash, options?: RequestOptions): Promise<Buffer> {

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -1,5 +1,6 @@
-import { Timestamp, ContentFileHash, ServerStatus, AuditInfo, EntityType, Pointer, EntityId, Entity, ServerName, DeploymentHistory, PartialDeploymentHistory, RequestOptions } from "dcl-catalyst-commons";
+import { Timestamp, ContentFileHash, ServerStatus, AuditInfo, EntityType, Pointer, EntityId, Entity, ServerName, LegacyDeploymentHistory, LegacyPartialDeploymentHistory, RequestOptions, DeploymentFilters, PartialDeploymentHistory, AvailableContentResult, DeploymentBase, DeploymentWithMetadata, DeploymentWithContent, DeploymentWithPointers, Deployment } from "dcl-catalyst-commons";
 import { DeploymentData } from './utils/DeploymentBuilder';
+import { DeploymentFields } from "ContentClient";
 
 export interface ContentAPI {
 
@@ -8,10 +9,13 @@ export interface ContentAPI {
     fetchEntitiesByIds(type: EntityType, ids: EntityId[], options?: RequestOptions): Promise<Entity[]>;
     fetchEntityById(type: EntityType, id: EntityId, options?: RequestOptions): Promise<Entity>;
     fetchAuditInfo(type: EntityType, id: EntityId, options?: RequestOptions): Promise<AuditInfo>;
-    fetchFullHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName}, options?: RequestOptions): Promise<DeploymentHistory>;
-    fetchHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName}, options?: RequestOptions): Promise<PartialDeploymentHistory>;
+    fetchFullHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName}, options?: RequestOptions): Promise<LegacyDeploymentHistory>;
+    fetchHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName, offset?: number, limit?: number}, options?: RequestOptions): Promise<LegacyPartialDeploymentHistory>;
     fetchStatus(options?: RequestOptions): Promise<ServerStatus>;
+    fetchAllDeployments<T extends DeploymentBase = Deployment>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]>;
+    fetchLastDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(offset?: number, limit?: number, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<PartialDeploymentHistory<T>>;
     downloadContent(contentHash: ContentFileHash, options?: RequestOptions): Promise<Buffer>;
+    isContentAvailable(cids: ContentFileHash[], options?: RequestOptions): Promise<AvailableContentResult>
 
     /** Upload */
     deployEntity(deployData: DeploymentData, fix?: boolean, options?: RequestOptions): Promise<Timestamp>;

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -6,6 +6,7 @@ import { DeploymentData } from './utils/DeploymentBuilder';
 
 export class ContentClient implements ContentAPI {
 
+    private static readonly CHARS_LEFT_FOR_OFFSET = 7
     private readonly contentUrl: string
 
     constructor(contentUrl: string,
@@ -137,8 +138,10 @@ export class ContentClient implements ContentAPI {
         queryParams.set('auditInfo', ['true'])
         type AddedAudit = T & DeploymentWithAuditInfo
 
+        // Reserve a few chars to send the offset
+        const reservedChars = `&offset=`.length + ContentClient.CHARS_LEFT_FOR_OFFSET
+
         // Split values into different queries
-        const reservedChars = `&offset=9999999`.length
         const queries = splitManyValuesIntoManyQueries(this.contentUrl, '/deployments', queryParams, reservedChars)
 
         // Perform the different queries

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -1,7 +1,7 @@
 require('isomorphic-form-data');
-import { Timestamp, Pointer, EntityType, Entity, EntityId, AuditInfo, ServerStatus, ServerName, ContentFileHash, DeploymentHistory, PartialDeploymentHistory, applySomeDefaults, retry, Fetcher, RequestOptions, Hashing } from "dcl-catalyst-commons";
+import { Timestamp, Pointer, EntityType, Entity, EntityId, AuditInfo, ServerStatus, ServerName, ContentFileHash, PartialDeploymentHistory, applySomeDefaults, retry, Fetcher, RequestOptions, Hashing, LegacyPartialDeploymentHistory, DeploymentFilters, Deployment, AvailableContentResult, LegacyDeploymentHistory, DeploymentWithMetadata, DeploymentWithContent, DeploymentWithPointers, DeploymentBase } from "dcl-catalyst-commons";
 import { ContentAPI } from './ContentAPI';
-import { convertModelToFormData, sanitizeUrl, splitValuesIntoManyQueries } from './utils/Helper';
+import { convertModelToFormData, sanitizeUrl, splitManyValuesIntoManyQueries, splitValuesIntoManyQueries } from './utils/Helper';
 import { DeploymentData } from './utils/DeploymentBuilder';
 
 export class ContentClient implements ContentAPI {
@@ -19,7 +19,7 @@ export class ContentClient implements ContentAPI {
         form.append('entityId', deployData.entityId)
         convertModelToFormData(deployData.authChain, form, 'authChain')
 
-        const alreadyUploadedHashes = await this.hashesAlreadyOnServer(Array.from(deployData.files.keys()))
+        const alreadyUploadedHashes = await this.hashesAlreadyOnServer(Array.from(deployData.files.keys()), options)
         for (const [fileHash, file] of deployData.files) {
             if (!alreadyUploadedHashes.has(fileHash)) {
                 // @ts-ignore
@@ -59,16 +59,16 @@ export class ContentClient implements ContentAPI {
         return this.fetchJson(`/audit/${type}/${id}`, options)
     }
 
-    async fetchFullHistory(query?: { from?: number; to?: number; serverName?: string }, options?: RequestOptions): Promise<DeploymentHistory> {
+    async fetchFullHistory(query?: { from?: number; to?: number; serverName?: string }, options?: RequestOptions): Promise<LegacyDeploymentHistory> {
         // We are setting different defaults in this case, because if one of the request fails, then all fail
         const withSomeDefaults = applySomeDefaults({ attempts: 3, waitTime: '1s' }, options)
 
-        let events: DeploymentHistory = []
+        let events: LegacyDeploymentHistory = []
         let offset = 0
         let keepRetrievingHistory = true
         while (keepRetrievingHistory) {
             const currentQuery = { ...query, offset}
-            const partialHistory: PartialDeploymentHistory = await this.fetchHistory(currentQuery, withSomeDefaults)
+            const partialHistory: LegacyPartialDeploymentHistory = await this.fetchHistory(currentQuery, withSomeDefaults)
             events.push(...partialHistory.events)
             offset = partialHistory.pagination.offset + partialHistory.pagination.limit
             keepRetrievingHistory = partialHistory.pagination.moreData
@@ -77,7 +77,7 @@ export class ContentClient implements ContentAPI {
         return events
     }
 
-    fetchHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName, offset?: number, limit?: number}, options?: RequestOptions): Promise<PartialDeploymentHistory> {
+    fetchHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName, offset?: number, limit?: number}, options?: RequestOptions): Promise<LegacyPartialDeploymentHistory> {
         let path = `/history?offset=${query?.offset ?? 0}`
         if (query?.from) {
             path += `&from=${query?.from}`
@@ -113,15 +113,83 @@ export class ContentClient implements ContentAPI {
         }, attempts, waitTime)
     }
 
-    /** Given an array of file hashes, return a set with those already uploaded on the server */
-    private async hashesAlreadyOnServer(hashes: ContentFileHash[]): Promise<Set<ContentFileHash>> {
-        if (hashes.length === 0) {
-            return new Set()
+    async fetchAllDeployments<T extends DeploymentBase = Deployment>(filters?: DeploymentFilters, fields: DeploymentFields<T> = DeploymentFields.POINTERS_CONTENT_METADATA_AND_AUDIT_INFO, options?: RequestOptions): Promise<T[]> {
+        // We are setting different defaults in this case, because if one of the request fails, then all fail
+        const withSomeDefaults = applySomeDefaults({ attempts: 3, waitTime: '1s' }, options)
+
+        // Transform filters object into query params map
+        let queryParams: Map<string, string[]> = new Map()
+        if (filters) {
+            const entries = Object.entries(filters).map<[string, string[]]>(([ name, value ]) => {
+                const newName = name.endsWith('s') ? name.slice(0, -1) : name
+                let newValues: string[]
+                if (Array.isArray(value)) {
+                    newValues = value.map(element => `${element}`)
+                } else {
+                    newValues = [ `${value}` ]
+                }
+                return [newName, newValues]
+            })
+            queryParams = new Map(entries)
+        }
+        queryParams.set('auditInfo', ['true'])
+
+        // Split values into different queries
+        const reservedChars = `&offset=9999999`.length
+        const queries = splitManyValuesIntoManyQueries(this.contentUrl, '/deployments', queryParams, reservedChars)
+
+        // Perform the different queries
+        const results: Deployment[] = []
+        for (const query of queries) {
+            let offset = 0
+            let keepRetrievingHistory = true
+            while (keepRetrievingHistory) {
+                const url = query + (queryParams.size === 0 ? '?' : '&') + `offset=${offset}`
+                const partialHistory: PartialDeploymentHistory<Deployment> = await this.fetcher.fetchJson(url, withSomeDefaults)
+                results.push(...partialHistory.deployments)
+                offset = partialHistory.pagination.offset + partialHistory.pagination.limit
+                keepRetrievingHistory = partialHistory.pagination.moreData
+            }
         }
 
-        type AvailableContentResult = { cid: ContentFileHash, available: boolean }
+        console.log("RESULTS", results)
 
-        const result: AvailableContentResult[] = await this.splitAndFetch<AvailableContentResult, ContentFileHash>(`/available-content`, 'cid', hashes, ({ cid }) => cid)
+        // Remove duplicates
+        const withoutDuplicates: Map<EntityId, Deployment> = new Map(results.map(deployment => [deployment.entityId, deployment]))
+
+        // Sort by local timestamp
+        let deployments = Array.from(withoutDuplicates.values())
+            .sort((deployment1, deployment2) => deployment1.auditInfo.localTimestamp - deployment2.auditInfo.localTimestamp)
+
+        if (!fields.getFields().includes('auditInfo')) {
+            deployments.forEach(deployment => delete deployment.auditInfo)
+        }
+        //@ts-ignore
+        return deployments
+    }
+
+    fetchLastDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(offset?: number, limit?: number, fields: DeploymentFields<T> = DeploymentFields.POINTERS_CONTENT_AND_METADATA, options?: RequestOptions): Promise<PartialDeploymentHistory<T>> {
+        let path = `/deployments?offset=${offset ?? 0}`
+        if (limit) {
+            path += `&limit=${limit}`
+        }
+        if (fields.getFields().includes('auditInfo')) {
+            path += `&auditInfo=true`
+        }
+        return this.fetchJson(path, options)
+    }
+
+    isContentAvailable(cids: string[], options?: RequestOptions): Promise<AvailableContentResult> {
+        if (cids.length === 0) {
+            return Promise.reject(`You must set at least one cid.`)
+        }
+
+        return this.splitAndFetch<{ cid: ContentFileHash, available: boolean }, ContentFileHash>(`/available-content`, 'cid', cids, ({ cid }) => cid, options)
+    }
+
+    /** Given an array of file hashes, return a set with those already uploaded on the server */
+    private async hashesAlreadyOnServer(hashes: ContentFileHash[], options: RequestOptions | undefined): Promise<Set<ContentFileHash>> {
+        const result: AvailableContentResult = await this.isContentAvailable(hashes, options)
 
         const alreadyUploaded = result.filter(({ available }) => available)
             .map(({ cid }) => cid)
@@ -141,7 +209,11 @@ export class ContentClient implements ContentAPI {
         const queries = splitValuesIntoManyQueries(this.contentUrl, basePath, queryParamName, values)
 
         // Perform the different queries
-        const results: E[][] = await Promise.all(queries.map(query => this.fetcher.fetchJson(query, options)))
+        const results: E[][] = [];
+        for (const query of queries) {
+            const result = await this.fetcher.fetchJson(query, options)
+            results.push(result)
+        }
 
         // Flatten results
         const flattenedResult: E[] = results.reduce((accum, value) => accum.concat(value), [])
@@ -155,6 +227,20 @@ export class ContentClient implements ContentAPI {
 
     private fetchJson(path: string, options?: RequestOptions): Promise<any> {
         return this.fetcher.fetchJson(`${this.contentUrl}${path}`, options)
+    }
+
+}
+
+//@ts-ignore
+export class DeploymentFields<T extends Partial<Deployment>> {
+
+    static readonly POINTERS_CONTENT_METADATA_AND_AUDIT_INFO = new DeploymentFields<Deployment>(['pointers', 'content', 'metadata' , 'auditInfo'])
+    static readonly POINTERS_CONTENT_AND_METADATA = new DeploymentFields<DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(['pointers', 'content', 'metadata'])
+
+    private constructor(private readonly fields: string[]) { }
+
+    getFields() {
+        return this.fields;
     }
 
 }

--- a/src/utils/DeploymentBuilder.ts
+++ b/src/utils/DeploymentBuilder.ts
@@ -1,5 +1,5 @@
-import { AuthChain } from 'dcl-crypto'
-import { Hashing, buildEntityAndFile, EntityType, Pointer, ContentFile, EntityContentItemReference, EntityMetadata, ContentFileHash, EntityId } from 'dcl-catalyst-commons';
+import { AuthChain, Timestamp } from 'dcl-crypto'
+import { Hashing, buildEntityAndFile, EntityType, Pointer, ContentFile, EntityContentItemReference, EntityMetadata, ContentFileHash, EntityId, Fetcher } from 'dcl-catalyst-commons';
 
 
 export class DeploymentBuilder {
@@ -8,7 +8,7 @@ export class DeploymentBuilder {
      * As part of the deployment process, an entity has to be built. In this method, we are building it, based on the data provided.
      * After the entity is built, the user will have to sign the entity id, to prove they are actually who they say they are.
      */
-    static async buildEntity(type: EntityType, pointers: Pointer[], files: Map<string, Buffer> = new Map(), metadata?: EntityMetadata): Promise<DeploymentPreparationData> {
+    static async buildEntity(type: EntityType, pointers: Pointer[], files: Map<string, Buffer> = new Map(), metadata?: EntityMetadata, fetchNow: boolean = true): Promise<DeploymentPreparationData> {
         // Make sure that there is at least one pointer
         if (pointers.length === 0) {
             throw new Error(`All entities must have at least one pointer.`)
@@ -22,8 +22,20 @@ export class DeploymentBuilder {
         const hashes = await Hashing.calculateHashes(contentFiles)
         const entityContent: EntityContentItemReference[] = hashes.map(({ hash, file }) => ({ file: file.name, hash }))
 
+        // Calculate timestamp. We will try to use a global time API, so if the local PC clock is off, it will still work
+        let timestamp: Timestamp = Date.now()
+        if (fetchNow) {
+            const fetcher = new Fetcher()
+            try {
+                const { datetime } = await fetcher.fetchJson('https://worldtimeapi.org/api/timezone/Etc/UTC')
+                timestamp = new Date(datetime).getTime()
+            } catch (e) {
+                timestamp = Date.now()
+            }
+        }
+
         // Build entity file
-        const { entity, entityFile } = await buildEntityAndFile(type, pointers, Date.now(), entityContent, metadata)
+        const { entity, entityFile } = await buildEntityAndFile(type, pointers, timestamp, entityContent, metadata)
 
         // Add entity file to content files
         hashes.push({ hash: entity.id, file: entityFile })

--- a/test/utils/DeploymentBuilder.spec.ts
+++ b/test/utils/DeploymentBuilder.spec.ts
@@ -23,7 +23,7 @@ describe('Deployment Builder', () => {
         const fileId = "Id"
         const contentFiles = new Map([[fileId, fileContent]])
 
-        const { entityId, files } = await DeploymentBuilder.buildEntity(EntityType.PROFILE, [pointer], contentFiles, someMetadata)
+        const { entityId, files } = await DeploymentBuilder.buildEntity(EntityType.PROFILE, [pointer], contentFiles, someMetadata, false)
 
         // Assertions
         expect(files.size).to.equal(2)


### PR DESCRIPTION
We are doing two things here:
1. We are adding new fetching methods that call the `/deployments` endpoint
2. We are using a global time API when creating new entities