### PR TITLE
feat: add deployments streaming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ references:
       at: *workspace_root
 
   .image_client: &image_client
-    image: circleci/node:10-browsers
+    image: circleci/node:12-browsers
 
   .working_directory_root: &working_directory_root
     working_directory: *workspace_root

--- a/package-lock.json
+++ b/package-lock.json
@@ -867,6 +867,11 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "async-iterator-to-array": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/async-iterator-to-array/-/async-iterator-to-array-0.0.1.tgz",
+      "integrity": "sha512-BH6nAEYCRjNh24ylW8juMrHq5k/wx2l3kLcFjVZQ3uNYNKHQmVb9UbXxDo9Z8YUjhCGTthUaR9hBf4aK+aHRQg=="
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "homepage": "https://github.com/decentraland/catalyst-client#readme",
   "dependencies": {
+    "async-iterator-to-array": "0.0.1",
     "dcl-catalyst-commons": "^1.4.0",
     "dcl-crypto": "^2.2.0",
     "isomorphic-form-data": "^2.0.0"

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -1,11 +1,12 @@
 import { EthAddress } from 'dcl-crypto'
-import { Timestamp, Pointer, EntityType, Entity, EntityId, ServerStatus, ServerName, ContentFileHash, Profile, Fetcher, RequestOptions, LegacyPartialDeploymentHistory, LegacyDeploymentHistory, DeploymentFilters, AvailableContentResult, DeploymentBase, DeploymentWithPointers, DeploymentWithContent, DeploymentWithMetadata, LegacyAuditInfo } from "dcl-catalyst-commons";
+import { Timestamp, Pointer, EntityType, Entity, EntityId, ServerStatus, ServerName, ContentFileHash, Profile, Fetcher, RequestOptions, LegacyPartialDeploymentHistory, LegacyDeploymentHistory, DeploymentFilters, AvailableContentResult, DeploymentBase, LegacyAuditInfo } from "dcl-catalyst-commons";
 import { Readable } from 'stream';
 import { CatalystAPI } from "./CatalystAPI";
 import { DeploymentData } from './utils/DeploymentBuilder';
 import { sanitizeUrl } from './utils/Helper';
 import { ContentClient, DeploymentFields } from './ContentClient';
 import { LambdasClient } from './LambdasClient';
+import { DeploymentWithMetadataContentAndPointers } from 'ContentAPI';
 
 export class CatalystClient implements CatalystAPI {
 
@@ -52,11 +53,11 @@ export class CatalystClient implements CatalystAPI {
         return this.contentClient.fetchStatus(options)
     }
 
-    fetchAllDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]> {
+    fetchAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]> {
         return this.contentClient.fetchAllDeployments(filters, fields, options)
     }
 
-    streamAllDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, errorListener?: (errorMessage: string) => void, options?: RequestOptions): Readable {
+    streamAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, errorListener?: (errorMessage: string) => void, options?: RequestOptions): Readable {
         return this.contentClient.streamAllDeployments(filters, fields, errorListener, options)
     }
 

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -1,10 +1,11 @@
 import { EthAddress } from 'dcl-crypto'
-import { Timestamp, Pointer, EntityType, Entity, EntityId, ServerStatus, ServerName, ContentFileHash, Profile, PartialDeploymentHistory, Fetcher, RequestOptions, LegacyPartialDeploymentHistory, LegacyDeploymentHistory, DeploymentFilters, AvailableContentResult, DeploymentBase, DeploymentWithPointers, DeploymentWithContent, DeploymentWithMetadata, Deployment, LegacyAuditInfo } from "dcl-catalyst-commons";
+import { Timestamp, Pointer, EntityType, Entity, EntityId, ServerStatus, ServerName, ContentFileHash, Profile, Fetcher, RequestOptions, LegacyPartialDeploymentHistory, LegacyDeploymentHistory, DeploymentFilters, AvailableContentResult, DeploymentBase, DeploymentWithPointers, DeploymentWithContent, DeploymentWithMetadata, LegacyAuditInfo } from "dcl-catalyst-commons";
 import { CatalystAPI } from "./CatalystAPI";
 import { DeploymentData } from './utils/DeploymentBuilder';
 import { sanitizeUrl } from './utils/Helper';
 import { ContentClient, DeploymentFields } from './ContentClient';
 import { LambdasClient } from './LambdasClient';
+import { Readable } from 'stream';
 
 export class CatalystClient implements CatalystAPI {
 
@@ -51,12 +52,12 @@ export class CatalystClient implements CatalystAPI {
         return this.contentClient.fetchStatus(options)
     }
 
-    fetchAllDeployments<T extends DeploymentBase = Deployment>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]> {
+    fetchAllDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]> {
         return this.contentClient.fetchAllDeployments(filters, fields, options)
     }
 
-    fetchLastDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(offset?: number, limit?: number, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<PartialDeploymentHistory<T>> {
-        return this.contentClient.fetchLastDeployments<T>(offset, limit, fields, options)
+    streamAllDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, errorListener?: (errorMessage: string) => void, options?: RequestOptions): Readable {
+        return this.contentClient.streamAllDeployments(filters, fields, errorListener, options)
     }
 
     isContentAvailable(cids: string[], options?: RequestOptions): Promise<AvailableContentResult> {

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -1,11 +1,11 @@
 import { EthAddress } from 'dcl-crypto'
 import { Timestamp, Pointer, EntityType, Entity, EntityId, ServerStatus, ServerName, ContentFileHash, Profile, Fetcher, RequestOptions, LegacyPartialDeploymentHistory, LegacyDeploymentHistory, DeploymentFilters, AvailableContentResult, DeploymentBase, DeploymentWithPointers, DeploymentWithContent, DeploymentWithMetadata, LegacyAuditInfo } from "dcl-catalyst-commons";
+import { Readable } from 'stream';
 import { CatalystAPI } from "./CatalystAPI";
 import { DeploymentData } from './utils/DeploymentBuilder';
 import { sanitizeUrl } from './utils/Helper';
 import { ContentClient, DeploymentFields } from './ContentClient';
 import { LambdasClient } from './LambdasClient';
-import { Readable } from 'stream';
 
 export class CatalystClient implements CatalystAPI {
 

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -1,7 +1,7 @@
 import { Timestamp, ContentFileHash, ServerStatus, EntityType, Pointer, EntityId, Entity, ServerName, LegacyDeploymentHistory, LegacyPartialDeploymentHistory, RequestOptions, DeploymentFilters, AvailableContentResult, DeploymentBase, DeploymentWithMetadata, DeploymentWithContent, DeploymentWithPointers, LegacyAuditInfo } from "dcl-catalyst-commons";
+import { Readable } from "stream";
 import { DeploymentData } from './utils/DeploymentBuilder';
 import { DeploymentFields } from "ContentClient";
-import { Readable } from "stream";
 
 export interface ContentAPI {
 

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -13,8 +13,8 @@ export interface ContentAPI {
     fetchFullHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName}, options?: RequestOptions): Promise<LegacyDeploymentHistory>;
     fetchHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName, offset?: number, limit?: number}, options?: RequestOptions): Promise<LegacyPartialDeploymentHistory>;
     fetchStatus(options?: RequestOptions): Promise<ServerStatus>;
-    fetchAllDeployments<T extends DeploymentBase = DeploymentWithMetadata & DeploymentWithContent & DeploymentWithPointers>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]>;
-    streamAllDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, errorListener?: (errorMessage: string) => void, options?: RequestOptions): Readable;
+    fetchAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]>;
+    streamAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, errorListener?: (errorMessage: string) => void, options?: RequestOptions): Readable;
     downloadContent(contentHash: ContentFileHash, options?: RequestOptions): Promise<Buffer>;
     isContentAvailable(cids: ContentFileHash[], options?: RequestOptions): Promise<AvailableContentResult>
 
@@ -22,3 +22,5 @@ export interface ContentAPI {
     deployEntity(deployData: DeploymentData, fix?: boolean, options?: RequestOptions): Promise<Timestamp>;
 
 }
+
+export type DeploymentWithMetadataContentAndPointers = DeploymentWithMetadata & DeploymentWithContent & DeploymentWithPointers

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -1,6 +1,7 @@
-import { Timestamp, ContentFileHash, ServerStatus, EntityType, Pointer, EntityId, Entity, ServerName, LegacyDeploymentHistory, LegacyPartialDeploymentHistory, RequestOptions, DeploymentFilters, PartialDeploymentHistory, AvailableContentResult, DeploymentBase, DeploymentWithMetadata, DeploymentWithContent, DeploymentWithPointers, Deployment, LegacyAuditInfo } from "dcl-catalyst-commons";
+import { Timestamp, ContentFileHash, ServerStatus, EntityType, Pointer, EntityId, Entity, ServerName, LegacyDeploymentHistory, LegacyPartialDeploymentHistory, RequestOptions, DeploymentFilters, AvailableContentResult, DeploymentBase, DeploymentWithMetadata, DeploymentWithContent, DeploymentWithPointers, LegacyAuditInfo } from "dcl-catalyst-commons";
 import { DeploymentData } from './utils/DeploymentBuilder';
 import { DeploymentFields } from "ContentClient";
+import { Readable } from "stream";
 
 export interface ContentAPI {
 
@@ -12,8 +13,8 @@ export interface ContentAPI {
     fetchFullHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName}, options?: RequestOptions): Promise<LegacyDeploymentHistory>;
     fetchHistory(query?: {from?: Timestamp, to?: Timestamp, serverName?: ServerName, offset?: number, limit?: number}, options?: RequestOptions): Promise<LegacyPartialDeploymentHistory>;
     fetchStatus(options?: RequestOptions): Promise<ServerStatus>;
-    fetchAllDeployments<T extends DeploymentBase = Deployment>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]>;
-    fetchLastDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(offset?: number, limit?: number, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<PartialDeploymentHistory<T>>;
+    fetchAllDeployments<T extends DeploymentBase = DeploymentWithMetadata & DeploymentWithContent & DeploymentWithPointers>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]>;
+    streamAllDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, errorListener?: (errorMessage: string) => void, options?: RequestOptions): Readable;
     downloadContent(contentHash: ContentFileHash, options?: RequestOptions): Promise<Buffer>;
     isContentAvailable(cids: ContentFileHash[], options?: RequestOptions): Promise<AvailableContentResult>
 

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -155,10 +155,12 @@ export class ContentClient implements ContentAPI {
 
         // Perform the different queries
         const foundIds: Set<EntityId> = new Set()
-        for (const query of queries) {
+        let exit = false
+        for (let i = 0; i < queries.length && !exit; i++) {
+            const query = queries[i]
             let offset = 0
             let keepRetrievingHistory = true
-            while (keepRetrievingHistory) {
+            while (keepRetrievingHistory && !exit) {
                 const url = query + (queryParams.size === 0 ? '?' : '&') + `offset=${offset}`
                 try {
                     const partialHistory: PartialDeploymentHistory<T> = await this.fetcher.fetchJson(url, withSomeDefaults)
@@ -174,7 +176,7 @@ export class ContentClient implements ContentAPI {
                     if (errorListener) {
                         errorListener(`${error}`)
                     }
-                    keepRetrievingHistory = false
+                    exit = true
                 }
             }
         }

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -1,5 +1,7 @@
 require('isomorphic-form-data');
 import { Timestamp, Pointer, EntityType, Entity, EntityId, ServerStatus, ServerName, ContentFileHash, PartialDeploymentHistory, applySomeDefaults, retry, Fetcher, RequestOptions, Hashing, LegacyPartialDeploymentHistory, DeploymentFilters, Deployment, AvailableContentResult, LegacyDeploymentHistory, DeploymentWithMetadata, DeploymentWithContent, DeploymentWithPointers, DeploymentBase, DeploymentWithAuditInfo, LegacyAuditInfo } from "dcl-catalyst-commons";
+import asyncToArray from 'async-iterator-to-array'
+import { Readable } from 'stream'
 import { ContentAPI } from './ContentAPI';
 import { addModelToFormData, sanitizeUrl, splitManyValuesIntoManyQueries, splitValuesIntoManyQueries } from './utils/Helper';
 import { DeploymentData } from './utils/DeploymentBuilder';
@@ -116,30 +118,34 @@ export class ContentClient implements ContentAPI {
         }, attempts, waitTime)
     }
 
-    async fetchAllDeployments<T extends DeploymentBase = Deployment>(filters?: DeploymentFilters, fields: DeploymentFields<T> = DeploymentFields.POINTERS_CONTENT_METADATA_AND_AUDIT_INFO, options?: RequestOptions): Promise<T[]> {
+    /**
+     * This method fetches all deployments that match the given filters. It is important to mention, that if there are too many filters, then the
+     * URL might get too long. In that case, we will internally make the necessary requests, but then the order of the deployments is not guaranteed.
+     */
+    fetchAllDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, options?: RequestOptions): Promise<T[]> {
+        return asyncToArray(this.iterateThroughDeployments(filters, fields, undefined, options))
+    }
+
+    streamAllDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, errorListener?: (errorMessage: string) => void, options?: RequestOptions): Readable {
+        return Readable.from(this.iterateThroughDeployments(filters, fields, errorListener, options))
+    }
+
+    private async * iterateThroughDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(filters?: DeploymentFilters, fields?: DeploymentFields<T>, errorListener?: (errorMessage: string) => void, options?: RequestOptions): AsyncIterable<T> {
         // We are setting different defaults in this case, because if one of the request fails, then all fail
         const withSomeDefaults = applySomeDefaults({ attempts: 3, waitTime: '1s' }, options)
 
         // Transform filters object into query params map
-        let queryParams: Map<string, string[]> = new Map()
-        if (filters) {
-            const entries = Object.entries(filters).map<[string, string[]]>(([ name, value ]) => {
-                const newName = name.endsWith('s') ? name.slice(0, -1) : name
-                let newValues: string[]
-                // Force coersion of number, boolean, or string into string
-                if (Array.isArray(value)) {
-                    newValues = [ ...value ].map(_ => `${_}`)
-                } else {
-                    newValues = [ `${value}` ]
-                }
-                return [newName, newValues]
-            })
-            queryParams = new Map(entries)
-        }
+        const queryParams: Map<string, string[]> = this.filtersToQueryParams(filters);
 
-        // Add audit info, since we need to sort by local timestamp
-        queryParams.set('showAudit', ['true'])
-        type AddedAudit = T & DeploymentWithAuditInfo
+        if (fields) {
+            const fieldsValue = fields.getFields()
+            queryParams.set('fields', [fieldsValue])
+
+            // TODO: Remove on next deployment
+            if (fieldsValue.includes('auditInfo')) {
+                queryParams.set('showAudit', ['true'])
+            }
+        }
 
         // Reserve a few chars to send the offset
         const reservedChars = `&offset=`.length + ContentClient.CHARS_LEFT_FOR_OFFSET
@@ -148,42 +154,48 @@ export class ContentClient implements ContentAPI {
         const queries = splitManyValuesIntoManyQueries(this.contentUrl, '/deployments', queryParams, reservedChars)
 
         // Perform the different queries
-        const results: AddedAudit[] = []
+        const foundIds: Set<EntityId> = new Set()
         for (const query of queries) {
             let offset = 0
             let keepRetrievingHistory = true
             while (keepRetrievingHistory) {
                 const url = query + (queryParams.size === 0 ? '?' : '&') + `offset=${offset}`
-                const partialHistory: PartialDeploymentHistory<AddedAudit> = await this.fetcher.fetchJson(url, withSomeDefaults)
-                results.push(...partialHistory.deployments)
-                offset = partialHistory.pagination.offset + partialHistory.pagination.limit
-                keepRetrievingHistory = partialHistory.pagination.moreData
+                try {
+                    const partialHistory: PartialDeploymentHistory<T> = await this.fetcher.fetchJson(url, withSomeDefaults)
+                    for (const deployment of partialHistory.deployments) {
+                        if (!foundIds.has(deployment.entityId)) {
+                            foundIds.add(deployment.entityId)
+                            yield deployment
+                        }
+                    }
+                    offset = partialHistory.pagination.offset + partialHistory.pagination.limit
+                    keepRetrievingHistory = partialHistory.pagination.moreData
+                } catch (error) {
+                    if (errorListener) {
+                        errorListener(`${error}`)
+                    }
+                    keepRetrievingHistory = false
+                }
             }
         }
-
-        // Remove duplicates
-        const withoutDuplicates: Map<EntityId, AddedAudit> = new Map(results.map(deployment => [deployment.entityId, deployment]))
-
-        // Sort by local timestamp
-        let deployments = Array.from(withoutDuplicates.values())
-            .sort((deployment1, deployment2) => deployment2.auditInfo.localTimestamp - deployment1.auditInfo.localTimestamp)
-
-        if (!fields.getFields().includes('auditInfo')) {
-            deployments.forEach(deployment => delete deployment.auditInfo)
-        }
-
-        return deployments
     }
 
-    fetchLastDeployments<T extends DeploymentBase = DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(offset?: number, limit?: number, fields: DeploymentFields<T> = DeploymentFields.POINTERS_CONTENT_AND_METADATA, options?: RequestOptions): Promise<PartialDeploymentHistory<T>> {
-        let path = `/deployments?offset=${offset ?? 0}`
-        if (limit) {
-            path += `&limit=${limit}`
+    private filtersToQueryParams(filters?: DeploymentFilters): Map<string, string[]> {
+        if (!filters) {
+            return new Map()
         }
-        if (fields.getFields().includes('auditInfo')) {
-            path += `&showAudit=true`
-        }
-        return this.fetchJson(path, options)
+        const entries = Object.entries(filters).map<[string, string[]]>(([name, value]) => {
+            const newName = name.endsWith('s') ? name.slice(0, -1) : name;
+            let newValues: string[];
+            // Force coersion of number, boolean, or string into string
+            if (Array.isArray(value)) {
+                newValues = [ ...value ].map(_ => `${_}`)
+            } else {
+                newValues = [ `${value}` ]
+            }
+            return [newName, newValues];
+        });
+        return new Map(entries);
     }
 
     isContentAvailable(cids: string[], options?: RequestOptions): Promise<AvailableContentResult> {
@@ -241,13 +253,14 @@ export class ContentClient implements ContentAPI {
 //@ts-ignore
 export class DeploymentFields<T extends Partial<Deployment>> {
 
+    static readonly AUDIT_INFO = new DeploymentFields<DeploymentWithAuditInfo>(['auditInfo'])
     static readonly POINTERS_CONTENT_METADATA_AND_AUDIT_INFO = new DeploymentFields<Deployment>(['pointers', 'content', 'metadata' , 'auditInfo'])
     static readonly POINTERS_CONTENT_AND_METADATA = new DeploymentFields<DeploymentWithPointers & DeploymentWithContent & DeploymentWithMetadata>(['pointers', 'content', 'metadata'])
 
     private constructor(private readonly fields: string[]) { }
 
-    getFields() {
-        return this.fields;
+    getFields(): string {
+        return this.fields.join(',');
     }
 
 }

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -131,28 +131,6 @@ describe('ContentClient', () => {
         verify(mocked.fetchJson(anything())).never()
     })
 
-    it('When fetching last deployments, then the result is as expected', async () => {
-        const [ offset, limit ] = [ 10, 20 ]
-        const requestResult: PartialDeploymentHistory<Deployment> = { filters: { }, deployments: [], pagination: { offset: 10, limit: 10, moreData: true } }
-        const { instance: fetcher } = mockFetcherJson(`/deployments?offset=${offset}&limit=${limit}`, requestResult)
-
-        const client = buildClient(URL, fetcher)
-        const result = await client.fetchLastDeployments(offset, limit)
-
-        expect(result).to.deep.equal(requestResult)
-    })
-
-    it('When fetching last deployments with audit info, then the result is as expected', async () => {
-        const [ offset, limit ] = [ 10, 20 ]
-        const requestResult: PartialDeploymentHistory<Deployment> = { filters: { }, deployments: [], pagination: { offset: 10, limit: 10, moreData: true } }
-        const { instance: fetcher } = mockFetcherJson(`/deployments?offset=${offset}&limit=${limit}&showAudit=true`, requestResult)
-
-        const client = buildClient(URL, fetcher)
-        const result = await client.fetchLastDeployments(offset, limit, DeploymentFields.POINTERS_CONTENT_METADATA_AND_AUDIT_INFO)
-
-        expect(result).to.deep.equal(requestResult)
-    })
-
     it('When fetching all deployments, then the result is as expected', async () => {
         const deployment = someDeployment()
         const filters = {
@@ -165,7 +143,7 @@ describe('ContentClient', () => {
             pointers: ['p1', 'p2'],
         }
         const requestResult: PartialDeploymentHistory<Deployment> = { filters: {  }, deployments: [ deployment ], pagination: { offset: 10, limit: 10, moreData: false } }
-        const { instance: fetcher } = mockFetcherJson(`/deployments?fromLocalTimestamp=20&toLocalTimestamp=30&onlyCurrentlyPointed=true&showAudit=true&deployedBy=eth1&deployedBy=eth2&entityType=profile&entityType=scene&entityId=id1&entityId=id2&pointer=p1&pointer=p2&offset=0`, requestResult)
+        const { instance: fetcher } = mockFetcherJson(`/deployments?fromLocalTimestamp=20&toLocalTimestamp=30&onlyCurrentlyPointed=true&deployedBy=eth1&deployedBy=eth2&entityType=profile&entityType=scene&entityId=id1&entityId=id2&pointer=p1&pointer=p2&offset=0`, requestResult)
 
         const client = buildClient(URL, fetcher)
         const result = await client.fetchAllDeployments(filters)
@@ -175,32 +153,14 @@ describe('ContentClient', () => {
 
     it('When fetching all deployments with no audit, then the result is as expected', async () => {
         const deployment = someDeployment()
+        delete deployment.auditInfo
         const requestResult: PartialDeploymentHistory<Deployment> = { filters: {  }, deployments: [ deployment ], pagination: { offset: 10, limit: 10, moreData: false } }
-        const { instance: fetcher } = mockFetcherJson(`/deployments?showAudit=true&offset=0`, requestResult)
+        const { instance: fetcher } = mockFetcherJson(`/deployments?fields=pointers,content,metadata&offset=0`, requestResult)
 
         const client = buildClient(URL, fetcher)
         const result = await client.fetchAllDeployments(undefined, DeploymentFields.POINTERS_CONTENT_AND_METADATA)
 
-        // Remove the audit info
-        const withoutAudit = { ...deployment }
-        delete withoutAudit.auditInfo
-
-        expect(result).to.deep.equal([ withoutAudit ])
-    })
-
-    it('When fetching all deployments with no audit, then the result is as expected', async () => {
-        const deployment = someDeployment()
-        const requestResult: PartialDeploymentHistory<Deployment> = { filters: {  }, deployments: [ deployment ], pagination: { offset: 10, limit: 10, moreData: false } }
-        const { instance: fetcher } = mockFetcherJson(`/deployments?showAudit=true&offset=0`, requestResult)
-
-        const client = buildClient(URL, fetcher)
-        const result = await client.fetchAllDeployments(undefined, DeploymentFields.POINTERS_CONTENT_AND_METADATA)
-
-        // Remove the audit info
-        const withoutAudit = { ...deployment }
-        delete withoutAudit.auditInfo
-
-        expect(result).to.deep.equal([ withoutAudit ])
+        expect(result).to.deep.equal([ deployment ])
     })
 
     it('When fetching all deployments with pagination, then the result is as expected', async () => {
@@ -209,8 +169,8 @@ describe('ContentClient', () => {
         const requestResult2: PartialDeploymentHistory<Deployment> = { filters: {  }, deployments: [ deployment1, deployment2 ], pagination: { offset: 1, limit: 2, moreData: false } }
 
         let mockedFetcher: Fetcher = mock(Fetcher);
-        when(mockedFetcher.fetchJson(`${URL}/deployments?showAudit=true&offset=0`, anything())).thenReturn(Promise.resolve(requestResult1))
-        when(mockedFetcher.fetchJson(`${URL}/deployments?showAudit=true&offset=1`, anything())).thenReturn(Promise.resolve(requestResult2))
+        when(mockedFetcher.fetchJson(`${URL}/deployments?offset=0`, anything())).thenReturn(Promise.resolve(requestResult1))
+        when(mockedFetcher.fetchJson(`${URL}/deployments?offset=1`, anything())).thenReturn(Promise.resolve(requestResult2))
         const fetcher = instance(mockedFetcher)
 
         const client = buildClient(URL, fetcher)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "outDir": "dist",
     "module": "commonjs",
     "target": "es2017",
-    "lib": ["es2017", "dom"],
+    "lib": ["es2017", "dom", "esnext.asynciterable"],
     "sourceMap": true,
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
We are adding deployment streaming to the catalyst client. This is mainly because the there are so many deployments that we would get an out of memory error if we tried to keep all the deployments in memory