### PR TITLE
fix: allow deployments in browser

### DIFF
--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -25,8 +25,14 @@ export class ContentClient implements ContentAPI {
         const alreadyUploadedHashes = await this.hashesAlreadyOnServer(Array.from(deployData.files.keys()), options)
         for (const [fileHash, file] of deployData.files) {
             if (!alreadyUploadedHashes.has(fileHash) || fileHash === deployData.entityId) {
-                // @ts-ignore
-                form.append(file.name, file.content, file.name)
+                if (typeof window === 'undefined') {
+                    // Node
+                    // @ts-ignore
+                    form.append(file.name, file.content, file.name)
+                } else {
+                    // Browser
+                    form.append(file.name, new Blob([file.content.buffer]), file.name)
+                }
             }
         }
 

--- a/src/utils/DeploymentBuilder.ts
+++ b/src/utils/DeploymentBuilder.ts
@@ -10,9 +10,7 @@ export class DeploymentBuilder {
      */
     static async buildEntity(type: EntityType, pointers: Pointer[], files: Map<string, Buffer> = new Map(), metadata?: EntityMetadata, timestamp?: Timestamp): Promise<DeploymentPreparationData> {
         // Make sure that there is at least one pointer
-        if (pointers.length === 0) {
-            throw new Error(`All entities must have at least one pointer.`)
-        }
+        DeploymentBuilder.assertThereIsAtLeastOnePointer(pointers)
 
         // Reorder input
         const contentFiles: ContentFile[] = Array.from(files.entries())
@@ -22,16 +20,8 @@ export class DeploymentBuilder {
         const hashes = await Hashing.calculateHashes(contentFiles)
         const entityContent: EntityContentItemReference[] = hashes.map(({ hash, file }) => ({ file: file.name, hash }))
 
-        // Calculate timestamp if necessary. We will try to use a global time API, so if the local PC clock is off, it will still work
-        if (!timestamp) {
-            const fetcher = new Fetcher()
-            try {
-                const { datetime } = await fetcher.fetchJson('https://worldtimeapi.org/api/timezone/Etc/UTC')
-                timestamp = new Date(datetime).getTime()
-            } catch (e) {
-                timestamp = Date.now()
-            }
-        }
+        // Calculate timestamp if necessary
+        timestamp = timestamp ?? await DeploymentBuilder.calculateTimestamp()
 
         // Build entity file
         const { entity, entityFile } = await buildEntityAndFile(type, pointers, timestamp, entityContent, metadata)
@@ -43,6 +33,42 @@ export class DeploymentBuilder {
         const filesByHash: Map<ContentFileHash, ContentFile> = new Map(hashes.map(({ hash, file }) =>  [hash, file]))
 
         return { files: filesByHash, entityId: entity.id }
+    }
+
+    /**
+     * In cases where we don't need to re-upload content files, we can simply generate the generate the new entity
+     */
+    static async buildEntityWithAlreadyUploadedHashes(type: EntityType, pointers: Pointer[], content: Map<string, ContentFileHash>, metadata?: EntityMetadata, timestamp?: Timestamp): Promise<DeploymentPreparationData> {
+        // Make sure that there is at least one pointer
+        DeploymentBuilder.assertThereIsAtLeastOnePointer(pointers)
+
+        // Re-organize the hashes
+        const entityContent: EntityContentItemReference[] = Array.from(content.entries()).map(([file, hash]) => ({ file, hash }))
+
+        // Calculate timestamp if necessary.
+        timestamp = timestamp ?? await DeploymentBuilder.calculateTimestamp()
+
+        // Build entity file
+        const { entity, entityFile } = await buildEntityAndFile(type, pointers, timestamp, entityContent, metadata)
+
+        return { files: new Map([[ entity.id, entityFile ]]), entityId: entity.id }
+    }
+
+    private static assertThereIsAtLeastOnePointer(pointers: Pointer[]): void {
+        if (pointers.length === 0) {
+            throw new Error(`All entities must have at least one pointer.`)
+        }
+    }
+
+    private static async calculateTimestamp(): Promise<Timestamp> {
+        // We will try to use a global time API, so if the local PC clock is off, it will still work
+        const fetcher = new Fetcher()
+        try {
+            const { datetime } = await fetcher.fetchJson('https://worldtimeapi.org/api/timezone/Etc/UTC')
+            return new Date(datetime).getTime()
+        } catch (e) {
+            return Date.now()
+        }
     }
 
 }

--- a/src/utils/DeploymentBuilder.ts
+++ b/src/utils/DeploymentBuilder.ts
@@ -22,9 +22,9 @@ export class DeploymentBuilder {
     }
 
     /**
-     * In cases where we don't need to re-upload content files, we can simply generate the new entity
+     * In cases where we don't need upload content files, we can simply generate the new entity. We can still use already uploaded hashes on this new entity.
      */
-    static async buildEntityWithAlreadyUploadedHashes(type: EntityType, pointers: Pointer[], content: Map<string, ContentFileHash>, metadata?: EntityMetadata, timestamp?: Timestamp): Promise<DeploymentPreparationData> {
+    static async buildEntityWithoutNewFiles(type: EntityType, pointers: Pointer[], content: Map<string, ContentFileHash> = new Map(), metadata?: EntityMetadata, timestamp?: Timestamp): Promise<DeploymentPreparationData> {
         return DeploymentBuilder.buildEntityInternal(type, pointers, content, metadata, timestamp)
     }
 


### PR DESCRIPTION
We are doing two things on this PR:
#### Fix for browser
The previous version of the code allowed deployments in NodeJs, but it didn't work when executed on the browser. Buffers and Blobs are not compatible, so we need to check and act accordingly

#### Add helper function
On the previous defined workflow, in order to build the entity itself, all files needed to be passed. The thing is, that if we are making a change on the metadata, the files may not change. In that case, we shouldn't force users to download the files and re-upload them. This is why we now expose `buildEntityWithAlreadyUploadedHashes`