### PR TITLE
refactor: remove getHistory from ContentClient

### DIFF
--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -6,12 +6,9 @@ import {
   Entity,
   EntityId,
   ServerStatus,
-  ServerName,
   ContentFileHash,
   Profile,
   Fetcher,
-  LegacyPartialDeploymentHistory,
-  LegacyDeploymentHistory,
   AvailableContentResult,
   DeploymentBase,
   LegacyAuditInfo,
@@ -65,20 +62,6 @@ export class CatalystClient implements CatalystAPI {
 
   fetchAuditInfo(type: EntityType, id: EntityId, options?: RequestOptions): Promise<LegacyAuditInfo> {
     return this.contentClient.fetchAuditInfo(type, id, options)
-  }
-
-  fetchFullHistory(
-    query?: { from?: number; to?: number; serverName?: string },
-    options?: RequestOptions
-  ): Promise<LegacyDeploymentHistory> {
-    return this.contentClient.fetchFullHistory(query, options)
-  }
-
-  fetchHistory(
-    query?: { from?: Timestamp; to?: Timestamp; serverName?: ServerName; offset?: number; limit?: number },
-    options?: RequestOptions
-  ): Promise<LegacyPartialDeploymentHistory> {
-    return this.contentClient.fetchHistory(query, options)
   }
 
   fetchStatus(options?: RequestOptions): Promise<ServerStatus> {

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -6,9 +6,6 @@ import {
   Pointer,
   EntityId,
   Entity,
-  ServerName,
-  LegacyDeploymentHistory,
-  LegacyPartialDeploymentHistory,
   AvailableContentResult,
   DeploymentBase,
   DeploymentWithMetadata,
@@ -27,14 +24,6 @@ export interface ContentAPI {
   fetchEntitiesByIds(type: EntityType, ids: EntityId[], options?: RequestOptions): Promise<Entity[]>
   fetchEntityById(type: EntityType, id: EntityId, options?: RequestOptions): Promise<Entity>
   fetchAuditInfo(type: EntityType, id: EntityId, options?: RequestOptions): Promise<LegacyAuditInfo>
-  fetchFullHistory(
-    query?: { from?: Timestamp; to?: Timestamp; serverName?: ServerName },
-    options?: RequestOptions
-  ): Promise<LegacyDeploymentHistory>
-  fetchHistory(
-    query?: { from?: Timestamp; to?: Timestamp; serverName?: ServerName; offset?: number; limit?: number },
-    options?: RequestOptions
-  ): Promise<LegacyPartialDeploymentHistory>
   fetchStatus(options?: RequestOptions): Promise<ServerStatus>
   fetchAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(
     deploymentOptions?: DeploymentOptions<T>,

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -6,18 +6,15 @@ import {
   Entity,
   EntityId,
   ServerStatus,
-  ServerName,
   ContentFileHash,
   PartialDeploymentHistory,
   applySomeDefaults,
   retry,
   Fetcher,
   Hashing,
-  LegacyPartialDeploymentHistory,
   DeploymentFilters,
   Deployment,
   AvailableContentResult,
-  LegacyDeploymentHistory,
   DeploymentBase,
   DeploymentWithAuditInfo,
   LegacyAuditInfo,
@@ -117,47 +114,6 @@ export class ContentClient implements ContentAPI {
     return this.fetchJson(`/audit/${type}/${id}`, options)
   }
 
-  async fetchFullHistory(
-    query?: { from?: number; to?: number; serverName?: string },
-    options?: RequestOptions
-  ): Promise<LegacyDeploymentHistory> {
-    // We are setting different defaults in this case, because if one of the request fails, then all fail
-    const withSomeDefaults = mergeRequestOptions({ attempts: 3, waitTime: '1s' }, options)
-
-    const events: LegacyDeploymentHistory = []
-    let offset = 0
-    let keepRetrievingHistory = true
-    while (keepRetrievingHistory) {
-      const currentQuery = { ...query, offset }
-      const partialHistory: LegacyPartialDeploymentHistory = await this.fetchHistory(currentQuery, withSomeDefaults)
-      events.push(...partialHistory.events)
-      offset = partialHistory.pagination.offset + partialHistory.pagination.limit
-      keepRetrievingHistory = partialHistory.pagination.moreData
-    }
-
-    return events
-  }
-
-  fetchHistory(
-    query?: { from?: Timestamp; to?: Timestamp; serverName?: ServerName; offset?: number; limit?: number },
-    options?: Partial<RequestOptions>
-  ): Promise<LegacyPartialDeploymentHistory> {
-    let path = `/history?offset=${query?.offset ?? 0}`
-    if (query?.from) {
-      path += `&from=${query?.from}`
-    }
-    if (query?.to) {
-      path += `&to=${query?.to}`
-    }
-    if (query?.serverName) {
-      path += `&serverName=${query?.serverName}`
-    }
-    if (query?.limit) {
-      path += `&limit=${query?.limit}`
-    }
-    return this.fetchJson(path, options)
-  }
-
   fetchStatus(options?: RequestOptions): Promise<ServerStatus> {
     return this.fetchJson('/status', options)
   }
@@ -219,8 +175,10 @@ export class ContentClient implements ContentAPI {
   }
 
   /**
-   * This method fetches all deployments that match the given filters. It is important to mention, that if there are too many filters, then the
-   * URL might get too long. In that case, we will internally make the necessary requests, but then the order of the deployments is not guaranteed.
+   * This method fetches all deployments that match the given filters.
+   *  It is important to mention, that if there are too many filters, then the URL might get too long.
+   *  In that case, we will internally make the necessary requests,
+   *  but then the order of the deployments is not guaranteed.
    */
   fetchAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(
     deploymentOptions?: DeploymentOptions<T>,
@@ -255,11 +213,6 @@ export class ContentClient implements ContentAPI {
     if (deploymentOptions?.fields) {
       const fieldsValue = deploymentOptions?.fields.getFields()
       queryParams.set('fields', [fieldsValue])
-
-      // TODO: Remove on next deployment
-      if (fieldsValue.includes('auditInfo')) {
-        queryParams.set('showAudit', ['true'])
-      }
     }
 
     // Reserve a few chars to send the offset


### PR DESCRIPTION
Removes `fetchHistory` and `fetchFullHistory` methods from `ContentClient`.