### PR TITLE
feat: add collection lambdas to client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1673,9 +1673,9 @@
       }
     },
     "dcl-catalyst-commons": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-2.1.0.tgz",
-      "integrity": "sha512-zbPndghPml/XhHEpSzOUDy0xmJGSE5bqeCjRfd7TAbaxsB8SyuAGjb093HLuVyGGCcVluAMhMMDKjr+dVZG9Uw==",
+      "version": "2.1.1-20210224181553.commit-6c89aeb",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-2.1.1-20210224181553.commit-6c89aeb.tgz",
+      "integrity": "sha512-JQrA+tZqJ4CK4o9/WI99a4ijsmCSnxPWp1oPUsRAfDt51Nvx2x4L1B52WOJUWDJS2XogTYv4grUatP0aUIbTKg==",
       "requires": {
         "@types/isomorphic-fetch": "0.0.35",
         "@types/ms": "^0.7.31",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/decentraland/catalyst-client#readme",
   "dependencies": {
     "async-iterator-to-array": "0.0.1",
-    "dcl-catalyst-commons": "^2.1.0",
+    "dcl-catalyst-commons": "^2.1.1-20210224181553.commit-6c89aeb",
     "dcl-crypto": "^2.2.0",
     "isomorphic-form-data": "git+https://github.com/decentraland/isomorphic-form-data.git#3409301b9e0348dc30da63955fa9fdb3ac46ac3e"
   },

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -15,7 +15,8 @@ import {
   AvailableContentResult,
   DeploymentBase,
   LegacyAuditInfo,
-  RequestOptions
+  RequestOptions,
+  CompleteRequestOptions
 } from 'dcl-catalyst-commons'
 import { Readable } from 'stream'
 import { CatalystAPI } from './CatalystAPI'
@@ -25,6 +26,7 @@ import { ContentClient, DeploymentOptions } from './ContentClient'
 import { LambdasClient } from './LambdasClient'
 import { DeploymentWithMetadataContentAndPointers } from './ContentAPI'
 import { RUNNING_VERSION } from './utils/Environment'
+import { WearablesFilters, OwnedWearables } from 'LambdasAPI'
 
 export class CatalystClient implements CatalystAPI {
   private readonly contentClient: ContentClient
@@ -117,5 +119,21 @@ export class CatalystClient implements CatalystAPI {
 
   fetchProfile(ethAddress: EthAddress, options?: RequestOptions): Promise<Profile> {
     return this.lambdasClient.fetchProfile(ethAddress, options)
+  }
+
+  fetchProfiles(ethAddresses: string[], options?: Partial<CompleteRequestOptions>): Promise<Profile[]> {
+    return this.lambdasClient.fetchProfiles(ethAddresses, options)
+  }
+
+  fetchWearables(filters: WearablesFilters, options?: Partial<CompleteRequestOptions>): Promise<any[]> {
+    return this.lambdasClient.fetchWearables(filters, options)
+  }
+
+  fetchOwnedWearables<B extends boolean>(
+    ethAddress: string,
+    includeDefinitions: B,
+    options?: Partial<CompleteRequestOptions>
+  ): Promise<OwnedWearables<B>> {
+    return this.lambdasClient.fetchOwnedWearables(ethAddress, includeDefinitions, options)
   }
 }

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -26,7 +26,7 @@ import { ContentClient, DeploymentOptions } from './ContentClient'
 import { LambdasClient } from './LambdasClient'
 import { DeploymentWithMetadataContentAndPointers } from './ContentAPI'
 import { RUNNING_VERSION } from './utils/Environment'
-import { WearablesFilters, OwnedWearables } from 'LambdasAPI'
+import { WearablesFilters, OwnedWearables } from './LambdasAPI'
 
 export class CatalystClient implements CatalystAPI {
   private readonly contentClient: ContentClient

--- a/src/LambdasAPI.ts
+++ b/src/LambdasAPI.ts
@@ -1,7 +1,34 @@
 import { EthAddress } from 'dcl-crypto'
-import { Profile, RequestOptions } from 'dcl-catalyst-commons'
+import { EntityMetadata, Profile, RequestOptions } from 'dcl-catalyst-commons'
 
 export interface LambdasAPI {
   /** Retrieve / Download */
   fetchProfile(ethAddress: EthAddress, options?: RequestOptions): Promise<Profile>
+
+  fetchProfiles(ethAddresses: EthAddress[], options?: RequestOptions): Promise<Profile[]>
+
+  fetchWearables(filters: WearablesFilters, options?: RequestOptions): Promise<EntityMetadata[]>
+
+  fetchOwnedWearables<B extends boolean>(
+    ethAddress: EthAddress,
+    includeDefinitions: B,
+    options?: RequestOptions
+  ): Promise<OwnedWearables<B>>
+}
+
+export type WearablesFilters = {
+  collectionIds?: string[]
+  wearableIds?: string[]
+  textSearch?: string
+}
+
+export type OwnedWearables<B extends boolean> = (B extends false
+  ? OwnedWearablesWithoutDefinition
+  : OwnedWearablesWithDefinition)[]
+
+export type OwnedWearablesWithDefinition = OwnedWearablesWithoutDefinition & { definition: EntityMetadata }
+
+export type OwnedWearablesWithoutDefinition = {
+  urn: string
+  amount: number
 }

--- a/src/LambdasClient.ts
+++ b/src/LambdasClient.ts
@@ -1,7 +1,13 @@
 import { EthAddress } from 'dcl-crypto'
-import { Profile, Fetcher, RequestOptions } from 'dcl-catalyst-commons'
-import { sanitizeUrl } from './utils/Helper'
-import { LambdasAPI } from './LambdasAPI'
+import { Profile, Fetcher, RequestOptions, EntityMetadata } from 'dcl-catalyst-commons'
+import { convertFiltersToQueryParams, sanitizeUrl, splitAndFetch, splitAndFetchPaginated } from './utils/Helper'
+import {
+  LambdasAPI,
+  OwnedWearables,
+  OwnedWearablesWithDefinition,
+  OwnedWearablesWithoutDefinition,
+  WearablesFilters
+} from './LambdasAPI'
 import { RUNNING_VERSION } from './utils/Environment'
 
 export class LambdasClient implements LambdasAPI {
@@ -21,5 +27,46 @@ export class LambdasClient implements LambdasAPI {
 
   fetchProfile(ethAddress: EthAddress, options?: RequestOptions): Promise<Profile> {
     return this.fetcher.fetchJson(`${this.lambdasUrl}/profile/${ethAddress}`, options)
+  }
+
+  fetchProfiles(ethAddresses: EthAddress[], options?: RequestOptions): Promise<Profile[]> {
+    return splitAndFetch<Profile>({
+      fetcher: this.fetcher,
+      baseUrl: this.lambdasUrl,
+      path: '/profiles',
+      queryParams: { name: 'id', values: ethAddresses },
+      options
+    })
+  }
+
+  fetchWearables(filters: WearablesFilters, options?: RequestOptions): Promise<EntityMetadata[]> {
+    const queryParams = convertFiltersToQueryParams(filters)
+    if (queryParams.size === 0) {
+      throw new Error('You must set at least one filter')
+    }
+
+    return splitAndFetchPaginated({
+      fetcher: this.fetcher,
+      baseUrl: this.lambdasUrl,
+      path: '/collections/wearables',
+      queryParams,
+      uniqueBy: 'id',
+      elementsProperty: 'wearables',
+      options
+    })
+  }
+
+  fetchOwnedWearables<B extends boolean>(
+    ethAddress: EthAddress,
+    includeDefinitions: B,
+    options?: RequestOptions
+  ): Promise<OwnedWearables<B>> {
+    return splitAndFetch<B extends false ? OwnedWearablesWithoutDefinition : OwnedWearablesWithDefinition>({
+      fetcher: this.fetcher,
+      baseUrl: this.lambdasUrl,
+      path: `/collections/wearables-by-owner/${ethAddress}`,
+      queryParams: { name: 'includeDefinitions', values: [`${includeDefinitions}`] },
+      options
+    })
   }
 }

--- a/src/utils/Helper.ts
+++ b/src/utils/Helper.ts
@@ -28,7 +28,7 @@ function removeDuplicates<T>(array: T[]): T[] {
 }
 
 /**
- * This method performs one or more fetches to the given server, splitting into different queries to avoid exceeding the max length of urls
+ * This method performs one or more fetches to the given server, splitting query params into different queries to avoid exceeding the max length of urls
  */
 export const MAX_URL_LENGTH: number = 2048
 export async function splitAndFetch<E>({
@@ -60,8 +60,8 @@ export async function splitAndFetch<E>({
 
 const CHARS_LEFT_FOR_OFFSET = 7
 /**
- * This method performs one or more fetches to the given server, splitting into different queries to avoid exceeding the max length of urls
- * This method should be use if the result is paginated, and needs to be queries many times
+ * This method performs one or more fetches to the given server, splitting query params into different queries to avoid exceeding the max length of urls
+ * This method should be used if the result is paginated, and needs to be queries many times
  */
 export async function splitAndFetchPaginated<E>({
   fetcher,

--- a/test/LambdasClient.spec.ts
+++ b/test/LambdasClient.spec.ts
@@ -1,0 +1,104 @@
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { mock, instance, when, anything } from 'ts-mockito'
+import { Fetcher } from 'dcl-catalyst-commons'
+import { LambdasClient } from 'index'
+
+chai.use(chaiAsPromised)
+const expect = chai.expect
+
+describe('LambdasClient', () => {
+  const URL = 'https://url.com'
+
+  it('When fetching for a profile, then the result is as expected', async () => {
+    const requestResult = someResult()
+    const ethAddress = 'ethAddress'
+    const { instance: fetcher } = mockFetcherJson(`/profile/${ethAddress}`, requestResult)
+
+    const client = buildClient(URL, fetcher)
+    const result = await client.fetchProfile(ethAddress)
+
+    expect(result).to.deep.equal(requestResult)
+  })
+
+  it('When fetching for many profiles, then the result is as expected', async () => {
+    const requestResult = [someResult()]
+    const [ethAddress1, ethAddress2] = ['ethAddress1', 'ethAddress2']
+    const { instance: fetcher } = mockFetcherJson(`/profiles?id=${ethAddress1}&id=${ethAddress2}`, requestResult)
+
+    const client = buildClient(URL, fetcher)
+    const result = await client.fetchProfiles([ethAddress1, ethAddress2])
+
+    expect(result).to.deep.equal(requestResult)
+  })
+
+  it('When fetching for wearables, then the result is as expected', async () => {
+    const wearables = [{ id: 'wearableId' }]
+    const requestResult = {
+      wearables,
+      pagination: { offset: 0, limit: 0, moreData: false }
+    }
+    const { instance: fetcher } = mockFetcherJson(
+      `/collections/wearables?textSearch=text&wearableId=id1&wearableId=id2&offset=0`,
+      requestResult
+    )
+
+    const client = buildClient(URL, fetcher)
+    const result = await client.fetchWearables({ wearableIds: ['id1', 'id2'], textSearch: 'text' })
+
+    expect(result).to.deep.equal(wearables)
+  })
+
+  it('When fetching for owned wearables without definition, then the result is as expected', async () => {
+    const ethAddress = 'ethAddress'
+    const requestResult = [{ urn: 'urn', amount: 10 }]
+    const { instance: fetcher } = mockFetcherJson(
+      `/collections/wearables-by-owner/${ethAddress}?includeDefinitions=false`,
+      requestResult
+    )
+
+    const client = buildClient(URL, fetcher)
+    const result = await client.fetchOwnedWearables(ethAddress, false)
+
+    expect(result).to.deep.equal(requestResult)
+  })
+
+  it('When fetching for owned wearables with definition, then the result is as expected', async () => {
+    const ethAddress = 'ethAddress'
+    const requestResult = [{ urn: 'urn', amount: 10, definition: {} }]
+    const { instance: fetcher } = mockFetcherJson(
+      `/collections/wearables-by-owner/${ethAddress}?includeDefinitions=true`,
+      requestResult
+    )
+
+    const client = buildClient(URL, fetcher)
+    const result = await client.fetchOwnedWearables(ethAddress, true)
+
+    expect(result).to.deep.equal(requestResult)
+  })
+
+  function someResult() {
+    return {
+      someKey: 'someValue'
+    }
+  }
+
+  function mockFetcherJson<T>(path?: string, result?: T): { mock: Fetcher; instance: Fetcher } {
+    // Create mock
+    const mockedFetcher: Fetcher = mock(Fetcher)
+
+    if (path) {
+      when(mockedFetcher.fetchJson(anything(), anything())).thenCall((url, _) => {
+        expect(url).to.equal(`${URL}${path}`)
+        return Promise.resolve(result)
+      })
+    }
+
+    // Getting instance from mock
+    return { mock: mockedFetcher, instance: instance(mockedFetcher) }
+  }
+
+  function buildClient(URL: string, fetcher: Fetcher) {
+    return new LambdasClient(URL, fetcher)
+  }
+})

--- a/test/utils/Helper.spec.ts
+++ b/test/utils/Helper.spec.ts
@@ -98,7 +98,7 @@ describe('Helper', () => {
     expect(query2).to.equal(buildQueryWithValues(valuesPerQuery, totalValues))
   })
 
-  it('When filters contain a non-basic type, then an error is thrown', () => {
+  it('When filters contain an invalid type, then an error is thrown', () => {
     const filters = {
       test: () => {}
     }

--- a/test/utils/Helper.spec.ts
+++ b/test/utils/Helper.spec.ts
@@ -1,5 +1,13 @@
 import chai from 'chai'
-import { sanitizeUrl, splitValuesIntoManyQueries, MAX_URL_LENGTH, splitManyValuesIntoManyQueries } from 'utils/Helper'
+import { Fetcher } from 'dcl-catalyst-commons'
+import { mock, when, anything, instance, verify } from 'ts-mockito'
+import {
+  sanitizeUrl,
+  splitValuesIntoManyQueries,
+  MAX_URL_LENGTH,
+  convertFiltersToQueryParams,
+  splitAndFetchPaginated
+} from 'utils/Helper'
 
 const expect = chai.expect
 
@@ -27,7 +35,11 @@ describe('Helper', () => {
 
     // Calculate queries
     const values = buildArray(value, totalValues)
-    const queries = splitValuesIntoManyQueries(baseUrl, basePath, queryParamName, values)
+    const queries = splitValuesIntoManyQueries({
+      baseUrl,
+      path: basePath,
+      queryParams: { name: queryParamName, values }
+    })
 
     // Calculate how many values could be in a query
     const valueLength = values[0].length
@@ -54,14 +66,14 @@ describe('Helper', () => {
 
     // Calculate queries
     const values = buildArray(value, totalValues)
-    const queries = splitManyValuesIntoManyQueries(
+    const queries = splitValuesIntoManyQueries({
       baseUrl,
-      basePath,
-      new Map([
+      path: basePath,
+      queryParams: new Map([
         [queryParamName1, ['a', 'b']],
         [queryParamName2, values]
       ])
-    )
+    })
 
     // Calculate how many values could be in a query
     const valueLength = values[0].length
@@ -84,6 +96,65 @@ describe('Helper', () => {
     const [query1, query2] = queries
     expect(query1).to.equal(buildQueryWithValues(0, valuesPerQuery))
     expect(query2).to.equal(buildQueryWithValues(valuesPerQuery, totalValues))
+  })
+
+  it('When filters contain a non-basic type, then an error is thrown', () => {
+    const filters = {
+      test: () => {}
+    }
+
+    expect(() => convertFiltersToQueryParams(filters)).to.throw(
+      'Query params must be either a string, a number, a boolean or an array of the types just mentioned'
+    )
+  })
+
+  it('When filters are valid, then they are converted into query params correctly', () => {
+    const filters = {
+      aBool: true,
+      aNum: 10,
+      aString: 'text',
+      anArray: [true, 10, 'text']
+    }
+
+    const queryParams = convertFiltersToQueryParams(filters)
+
+    expect(queryParams.size).to.equal(4)
+    expect(queryParams.get('aBool')).to.deep.equal(['true'])
+    expect(queryParams.get('aNum')).to.deep.equal(['10'])
+    expect(queryParams.get('aString')).to.deep.equal(['text'])
+    expect(queryParams.get('anArray')).to.deep.equal(['true', '10', 'text'])
+  })
+
+  it('When fetching paginated, then subsequent calls are made correctly', async () => {
+    const baseUrl = 'http://base.com'
+    const path = '/path'
+    const queryParams = { name: 'someName', values: ['value1', 'value2'] }
+
+    const mockedFetcher: Fetcher = mock(Fetcher)
+    when(
+      mockedFetcher.fetchJson('http://base.com/path?someName=value1&someName=value2&offset=0', anything())
+    ).thenResolve({
+      elements: [{ id: 'id1' }, { id: 'id2' }],
+      pagination: { offset: 0, limit: 2, moreData: true }
+    })
+    when(
+      mockedFetcher.fetchJson('http://base.com/path?someName=value1&someName=value2&offset=2', anything())
+    ).thenResolve({
+      elements: [{ id: 'id2' }, { id: 'id3' }],
+      pagination: { offset: 2, limit: 2, moreData: false }
+    })
+
+    const result = await splitAndFetchPaginated<{ id: string }>({
+      fetcher: instance(mockedFetcher),
+      baseUrl,
+      path,
+      queryParams,
+      elementsProperty: 'elements',
+      uniqueBy: 'id'
+    })
+
+    verify(mockedFetcher.fetchJson(anything(), anything())).twice()
+    expect(result).to.deep.equal([{ id: 'id1' }, { id: 'id2' }, { id: 'id3' }])
   })
 
   function buildArray(base: string, cases: number): string[] {


### PR DESCRIPTION
We are mainly adding callers to the new collection endpoints:
* `/profiles`
* `/collections/wearables`
* `/collections/wearables-by-owner/:ethAddress`

In doing so, we refactored a lot of the logic that previously only applied to the `ContentClient`, and moved it to a helper, so that it could also be used by the `LambdasClient`