### PR TITLE
[Breaking Change] fix: avoid very expensive calls to content server

### DIFF
--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -94,7 +94,7 @@ export class CatalystClient implements CatalystAPI {
   }
 
   streamAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(
-    deploymentOptions?: DeploymentOptions<T>,
+    deploymentOptions: DeploymentOptions<T>,
     options?: RequestOptions
   ): Readable {
     return this.contentClient.streamAllDeployments(deploymentOptions, options)

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -15,8 +15,7 @@ import {
   AvailableContentResult,
   DeploymentBase,
   LegacyAuditInfo,
-  RequestOptions,
-  CompleteRequestOptions
+  RequestOptions
 } from 'dcl-catalyst-commons'
 import { Readable } from 'stream'
 import { CatalystAPI } from './CatalystAPI'
@@ -88,7 +87,7 @@ export class CatalystClient implements CatalystAPI {
   }
 
   fetchAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(
-    deploymentOptions?: DeploymentOptions<T>,
+    deploymentOptions: DeploymentOptions<T>,
     options?: RequestOptions
   ): Promise<T[]> {
     return this.contentClient.fetchAllDeployments(deploymentOptions, options)
@@ -117,22 +116,18 @@ export class CatalystClient implements CatalystAPI {
     return this.contentClient.pipeContent(contentHash, writeTo, options)
   }
 
-  fetchProfile(ethAddress: EthAddress, options?: RequestOptions): Promise<Profile> {
-    return this.lambdasClient.fetchProfile(ethAddress, options)
-  }
-
-  fetchProfiles(ethAddresses: string[], options?: Partial<CompleteRequestOptions>): Promise<Profile[]> {
+  fetchProfiles(ethAddresses: EthAddress[], options?: RequestOptions): Promise<Profile[]> {
     return this.lambdasClient.fetchProfiles(ethAddresses, options)
   }
 
-  fetchWearables(filters: WearablesFilters, options?: Partial<CompleteRequestOptions>): Promise<any[]> {
+  fetchWearables(filters: WearablesFilters, options?: RequestOptions): Promise<any[]> {
     return this.lambdasClient.fetchWearables(filters, options)
   }
 
   fetchOwnedWearables<B extends boolean>(
-    ethAddress: string,
+    ethAddress: EthAddress,
     includeDefinitions: B,
-    options?: Partial<CompleteRequestOptions>
+    options?: RequestOptions
   ): Promise<OwnedWearables<B>> {
     return this.lambdasClient.fetchOwnedWearables(ethAddress, includeDefinitions, options)
   }

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -41,7 +41,7 @@ export interface ContentAPI {
     options?: RequestOptions
   ): Promise<T[]>
   streamAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(
-    deploymentOptions?: DeploymentOptions<T>,
+    deploymentOptions: DeploymentOptions<T>,
     options?: RequestOptions
   ): Readable
   downloadContent(contentHash: ContentFileHash, options?: RequestOptions): Promise<Buffer>

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -37,7 +37,7 @@ export interface ContentAPI {
   ): Promise<LegacyPartialDeploymentHistory>
   fetchStatus(options?: RequestOptions): Promise<ServerStatus>
   fetchAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(
-    deploymentOptions?: DeploymentOptions<T>,
+    deploymentOptions: DeploymentOptions<T>,
     options?: RequestOptions
   ): Promise<T[]>
   streamAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -244,7 +244,7 @@ export class ContentClient implements ContentAPI {
   }
 
   streamAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(
-    deploymentOptions?: DeploymentOptions<T>,
+    deploymentOptions: DeploymentOptions<T>,
     options?: RequestOptions
   ): Readable {
     return Readable.from(this.iterateThroughDeployments(deploymentOptions, options))

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -237,7 +237,7 @@ export class ContentClient implements ContentAPI {
    * URL might get too long. In that case, we will internally make the necessary requests, but then the order of the deployments is not guaranteed.
    */
   fetchAllDeployments<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(
-    deploymentOptions?: DeploymentOptions<T>,
+    deploymentOptions: DeploymentOptions<T>,
     options?: RequestOptions
   ): Promise<T[]> {
     return asyncToArray(this.iterateThroughDeployments(deploymentOptions, options))
@@ -259,6 +259,9 @@ export class ContentClient implements ContentAPI {
 
     // Transform filters object into query params map
     const filterQueryParams: Map<string, string[]> = convertFiltersToQueryParams(deploymentOptions?.filters)
+
+    // Validate that some params were used, so that not everything is fetched
+    this.assertFiltersAreSet(deploymentOptions?.filters)
 
     // Transform sorting object into query params map
     const sortingQueryParams = this.sortingToQueryParams(deploymentOptions?.sortBy)
@@ -311,6 +314,19 @@ export class ContentClient implements ContentAPI {
     }
   }
 
+  private assertFiltersAreSet(filters: DeploymentFilters | undefined) {
+    const filtersAreSet =
+      filters?.fromLocalTimestamp ||
+      filters?.toLocalTimestamp ||
+      (filters?.deployedBy && filters?.deployedBy.length > 0) ||
+      (filters?.entityTypes && filters?.entityTypes.length > 0) ||
+      (filters?.entityIds && filters?.entityIds.length > 0) ||
+      (filters?.pointers && filters?.pointers.length > 0)
+    if (!filtersAreSet) {
+      throw new Error(`When fetching deployments, you must set at least one filter that isn't 'onlyCurrentlyPointed'`)
+    }
+  }
+
   private sortingToQueryParams(sort?: DeploymentSorting): Map<string, string[]> {
     const sortQueryParams: Map<string, string[]> = new Map()
     if (sort?.field) {
@@ -355,7 +371,7 @@ export class ContentClient implements ContentAPI {
 }
 
 export type DeploymentOptions<T> = {
-  filters?: DeploymentFilters
+  filters: DeploymentFilters
   sortBy?: DeploymentSorting
   fields?: DeploymentFields<T>
   errorListener?: (errorMessage: string) => void

--- a/src/LambdasAPI.ts
+++ b/src/LambdasAPI.ts
@@ -2,8 +2,6 @@ import { EthAddress } from 'dcl-crypto'
 import { EntityMetadata, Profile, RequestOptions } from 'dcl-catalyst-commons'
 
 export interface LambdasAPI {
-  /** Retrieve / Download */
-  fetchProfile(ethAddress: EthAddress, options?: RequestOptions): Promise<Profile>
 
   fetchProfiles(ethAddresses: EthAddress[], options?: RequestOptions): Promise<Profile[]>
 

--- a/src/LambdasClient.ts
+++ b/src/LambdasClient.ts
@@ -25,10 +25,6 @@ export class LambdasClient implements LambdasAPI {
       })
   }
 
-  fetchProfile(ethAddress: EthAddress, options?: RequestOptions): Promise<Profile> {
-    return this.fetcher.fetchJson(`${this.lambdasUrl}/profile/${ethAddress}`, options)
-  }
-
   fetchProfiles(ethAddresses: EthAddress[], options?: RequestOptions): Promise<Profile[]> {
     return splitAndFetch<Profile>({
       fetcher: this.fetcher,

--- a/test/LambdasClient.spec.ts
+++ b/test/LambdasClient.spec.ts
@@ -10,17 +10,6 @@ const expect = chai.expect
 describe('LambdasClient', () => {
   const URL = 'https://url.com'
 
-  it('When fetching for a profile, then the result is as expected', async () => {
-    const requestResult = someResult()
-    const ethAddress = 'ethAddress'
-    const { instance: fetcher } = mockFetcherJson(`/profile/${ethAddress}`, requestResult)
-
-    const client = buildClient(URL, fetcher)
-    const result = await client.fetchProfile(ethAddress)
-
-    expect(result).to.deep.equal(requestResult)
-  })
-
   it('When fetching for many profiles, then the result is as expected', async () => {
     const requestResult = [someResult()]
     const [ethAddress1, ethAddress2] = ['ethAddress1', 'ethAddress2']


### PR DESCRIPTION
We are doing 2 changes in this PR. 

On one side, we are removing the `fetchProfile` method, since we will be deprecating that endpoint

On the other side, we are now making filters required when fetching or streaming deployments. This is to avoid certain calls to the content server that would fetch all existing deployments