### PR TITLE
fix: avoid blob error

### DIFF
--- a/src/CatalystAPI.ts
+++ b/src/CatalystAPI.ts
@@ -1,4 +1,6 @@
 import { ContentAPI } from './ContentAPI'
 import { LambdasAPI } from './LambdasAPI'
 
-export interface CatalystAPI extends ContentAPI, LambdasAPI {}
+export interface CatalystAPI extends ContentAPI, LambdasAPI {
+  getCatalystUrl(): string
+}

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -29,13 +29,14 @@ import { clientConnectedToCatalystIn } from './utils/CatalystClientBuilder'
 export class CatalystClient implements CatalystAPI {
   private readonly contentClient: ContentClient
   private readonly lambdasClient: LambdasClient
+  private readonly catalystUrl: string
 
   constructor(
     catalystUrl: string,
     origin: string, // The name or a description of the app that is using the client
     fetcher?: Fetcher
   ) {
-    catalystUrl = sanitizeUrl(catalystUrl)
+    this.catalystUrl = sanitizeUrl(catalystUrl)
     fetcher =
       fetcher ??
       new Fetcher({
@@ -43,8 +44,8 @@ export class CatalystClient implements CatalystAPI {
           'User-Agent': `catalyst-client/${RUNNING_VERSION} (+https://github.com/decentraland/catalyst-client)`
         }
       })
-    this.contentClient = new ContentClient(catalystUrl + '/content', origin, fetcher)
-    this.lambdasClient = new LambdasClient(catalystUrl + '/lambdas', fetcher)
+    this.contentClient = new ContentClient(this.catalystUrl + '/content', origin, fetcher)
+    this.lambdasClient = new LambdasClient(this.catalystUrl + '/lambdas', fetcher)
   }
 
   deployEntity(deployData: DeploymentData, fix: boolean = false, options?: RequestOptions): Promise<Timestamp> {
@@ -123,6 +124,18 @@ export class CatalystClient implements CatalystAPI {
 
   fetchLambdasStatus(options?: RequestOptions): Promise<{ contentServerUrl: string }> {
     return this.lambdasClient.fetchLambdasStatus(options)
+  }
+
+  getCatalystUrl(): string {
+    return this.catalystUrl
+  }
+
+  getContentUrl(): string {
+    return this.contentClient.getContentUrl()
+  }
+
+  getLambdasUrl(): string {
+    return this.lambdasClient.getLambdasUrl()
   }
 
   public static connectedToCatalystIn(network: 'mainnet' | 'ropsten', origin: string): Promise<CatalystClient> {

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -43,6 +43,9 @@ export interface ContentAPI {
 
   /** Upload */
   deployEntity(deployData: DeploymentData, fix?: boolean, options?: RequestOptions): Promise<Timestamp>
+
+  /** Status */
+  getContentUrl(): string
 }
 
 export type DeploymentWithMetadataContentAndPointers = DeploymentWithMetadata &

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -63,7 +63,7 @@ export class ContentClient implements ContentAPI {
     const alreadyUploadedHashes = await this.hashesAlreadyOnServer(Array.from(deployData.files.keys()), options)
     for (const [fileHash, file] of deployData.files) {
       if (!alreadyUploadedHashes.has(fileHash) || fileHash === deployData.entityId) {
-        if (typeof window === 'undefined') {
+        if (typeof window === 'undefined' || !('Blob' in globalThis)) {
           // Node
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
@@ -309,6 +309,10 @@ export class ContentClient implements ContentAPI {
       uniqueBy: 'cid',
       options
     })
+  }
+
+  getContentUrl(): string {
+    return this.contentUrl
   }
 
   /** Given an array of file hashes, return a set with those already uploaded on the server */

--- a/src/LambdasAPI.ts
+++ b/src/LambdasAPI.ts
@@ -15,6 +15,8 @@ export interface LambdasAPI {
   fetchCatalystsApprovedByDAO(options?: RequestOptions): Promise<ServerMetadata[]>
 
   fetchLambdasStatus(options?: RequestOptions): Promise<{ contentServerUrl: string }>
+
+  getLambdasUrl(): string
 }
 
 export type WearablesFilters = {

--- a/src/LambdasClient.ts
+++ b/src/LambdasClient.ts
@@ -73,4 +73,8 @@ export class LambdasClient implements LambdasAPI {
   fetchLambdasStatus(options?: RequestOptions): Promise<{ contentServerUrl: string }> {
     return this.fetcher.fetchJson(`${this.lambdasUrl}/status`, options)
   }
+
+  getLambdasUrl(): string {
+    return this.lambdasUrl
+  }
 }


### PR DESCRIPTION
We are doing 2 things on this PR:
* Since clients can be created with a random catalyst, we are now exposing the catalyst/content/lambdas url
* We are making a fix to avoid an error we've seen: `ReferenceError: Blob is not defined`