### PR TITLE
perf: use local timestamp instead of offset when possible

### DIFF
--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -251,22 +251,12 @@ export class ContentClient implements ContentAPI {
       reservedChars = '&fromLocalTimestamp='.length + 13
       if (deploymentOptions?.sortBy?.order === SortingOrder.ASCENDING) {
         // Ascending
-        modifyQueryBasedOnResult = (result, builder) => {
-          const newestDeployment = result.deployments[result.deployments.length - 1]
-          if (newestDeployment) {
-            // @ts-ignore
-            builder.setParam('fromLocalTimestamp', newestDeployment.auditInfo.localTimestamp)
-          }
-        }
+        modifyQueryBasedOnResult = (result, builder) =>
+          this.setParamBasedOnResult<T>('fromLocalTimestamp', result, builder)
       } else {
         // Descending
-        modifyQueryBasedOnResult = (result, builder) => {
-          const oldestDeployment = result.deployments[result.deployments.length - 1]
-          if (oldestDeployment) {
-            // @ts-ignore
-            builder.setParam('toLocalTimestamp', oldestDeployment.auditInfo.localTimestamp)
-          }
-        }
+        modifyQueryBasedOnResult = (result, builder) =>
+          this.setParamBasedOnResult<T>('toLocalTimestamp', result, builder)
       }
     } else {
       // We will use offset then
@@ -326,6 +316,18 @@ export class ContentClient implements ContentAPI {
           exit = true
         }
       }
+    }
+  }
+
+  private setParamBasedOnResult<T extends DeploymentBase = DeploymentWithMetadataContentAndPointers>(
+    paramName: string,
+    result: PartialDeploymentHistory<T>,
+    builder: QueryBuilder
+  ) {
+    const lastDeployment = result.deployments[result.deployments.length - 1]
+    if (lastDeployment) {
+      // @ts-ignore
+      builder.setParam(paramName, lastDeployment.auditInfo.localTimestamp)
     }
   }
 

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -166,7 +166,7 @@ describe('ContentClient', () => {
       pagination: { offset: 10, limit: 10, moreData: false }
     }
     const { instance: fetcher } = mockFetcherJson(
-      `/deployments?fromLocalTimestamp=20&toLocalTimestamp=30&onlyCurrentlyPointed=true&deployedBy=eth1&deployedBy=eth2&entityType=profile&entityType=scene&entityId=id1&entityId=id2&pointer=p1&pointer=p2&offset=0`,
+      `/deployments?fromLocalTimestamp=20&toLocalTimestamp=30&onlyCurrentlyPointed=true&deployedBy=eth1&deployedBy=eth2&entityType=profile&entityType=scene&entityId=id1&entityId=id2&pointer=p1&pointer=p2`,
       requestResult
     )
 
@@ -185,7 +185,7 @@ describe('ContentClient', () => {
       pagination: { offset: 10, limit: 10, moreData: false }
     }
     const { instance: fetcher } = mockFetcherJson(
-      `/deployments?entityType=${EntityType.PROFILE}&fields=pointers,content,metadata&offset=0`,
+      `/deployments?entityType=${EntityType.PROFILE}&fields=pointers,content,metadata`,
       requestResult
     )
 
@@ -224,7 +224,7 @@ describe('ContentClient', () => {
       pagination: { offset: 10, limit: 10, moreData: false }
     }
     const { instance: fetcher } = mockFetcherJson(
-      `/deployments?entityType=${EntityType.PROFILE}&sortingField=entity_timestamp&sortingOrder=ASC&offset=0`,
+      `/deployments?entityType=${EntityType.PROFILE}&sortingField=entity_timestamp&sortingOrder=ASC`,
       requestResult
     )
 
@@ -251,9 +251,9 @@ describe('ContentClient', () => {
     }
 
     const mockedFetcher: Fetcher = mock(Fetcher)
-    when(
-      mockedFetcher.fetchJson(`${URL}/deployments?entityType=${EntityType.PROFILE}&offset=0`, anything())
-    ).thenReturn(Promise.resolve(requestResult1))
+    when(mockedFetcher.fetchJson(`${URL}/deployments?entityType=${EntityType.PROFILE}`, anything())).thenReturn(
+      Promise.resolve(requestResult1)
+    )
     when(
       mockedFetcher.fetchJson(`${URL}/deployments?entityType=${EntityType.PROFILE}&offset=1`, anything())
     ).thenReturn(Promise.resolve(requestResult2))


### PR DESCRIPTION
The idea is to use the deployments' local timestamp when handling pagination, instead of using the offset. This is so that the query is simpler to handle for the database. However, this will only be possible to do when the following two conditions are met:
* The field `auditInfo` is asked for in the request
* The sort by field is `localTimestamp` (or it isn't set, since `localTimestamp` is the default)

### Implementation details
We are doing two big changes
1. We are using the local timestamp for pagination when possible
2. We are now exposing `QueryBuilders`. These are objects that help build final queries based on the base url and query parameters. They weren't exposed before, but since we want to be able to easily change the query params, it made sense to expose them