### PR TITLE
fix: support multiple reserved parameters

### DIFF
--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -238,7 +238,7 @@ export class ContentClient implements ContentAPI {
       queryParams.set('fields', [fieldsValue])
     }
 
-    let reservedChars: number
+    let reservedParams: Map<string, number>
     let modifyQueryBasedOnResult: (result: PartialDeploymentHistory<T>, builder: QueryBuilder) => void
 
     const canWeUseLocalTimestampInsteadOfOffset =
@@ -248,7 +248,10 @@ export class ContentClient implements ContentAPI {
 
     if (canWeUseLocalTimestampInsteadOfOffset) {
       // Note: the approach used below will get stuck if all 500 deployments on the same page have the same localTimestamp, but that is extremely unlikely
-      reservedChars = '&fromLocalTimestamp='.length + 13
+      reservedParams = new Map([
+        ['fromLocalTimestamp', 13],
+        ['toLocalTimestamp', 13]
+      ])
       if (deploymentOptions?.sortBy?.order === SortingOrder.ASCENDING) {
         // Ascending
         modifyQueryBasedOnResult = (result, builder) =>
@@ -260,14 +263,14 @@ export class ContentClient implements ContentAPI {
       }
     } else {
       // We will use offset then
-      reservedChars = `&offset=`.length + ContentClient.CHARS_LEFT_FOR_OFFSET
+      reservedParams = new Map([['offset', ContentClient.CHARS_LEFT_FOR_OFFSET]])
       modifyQueryBasedOnResult = (result, queryBuilder) =>
         queryBuilder.setParam('offset', result.pagination.limit + result.pagination.offset)
     }
 
     yield* this.iterateThroughDeploymentsBasedOnResult<T>(
       queryParams,
-      reservedChars,
+      reservedParams,
       modifyQueryBasedOnResult,
       deploymentOptions?.errorListener,
       withSomeDefaults
@@ -278,7 +281,7 @@ export class ContentClient implements ContentAPI {
     T extends DeploymentBase = DeploymentWithMetadataContentAndPointers
   >(
     queryParams: Map<string, string[]>,
-    reservedChars: number,
+    reservedParams: Map<string, number>,
     modifyQueryBasedOnResult: (result: PartialDeploymentHistory<T>, builder: QueryBuilder) => void,
     errorListener?: (errorMessage: string) => void,
     options?: RequestOptions
@@ -288,7 +291,7 @@ export class ContentClient implements ContentAPI {
       baseUrl: this.contentUrl,
       path: '/deployments',
       queryParams,
-      reservedChars
+      reservedParams
     })
 
     // Perform the different queries

--- a/src/utils/Helper.ts
+++ b/src/utils/Helper.ts
@@ -248,13 +248,7 @@ export class QueryBuilder {
     private readonly queryParams: Map<string, string[]> = new Map(),
     private readonly reservedParams: Map<string, number> = new Map()
   ) {
-    this.length = this.baseUrl.length
-    for (const [paramName, reserved] of reservedParams) {
-      this.length += paramName.length + 2 + reserved
-    }
-    for (const [paramName, paramValues] of queryParams) {
-      this.length += this.calculateAddedLength(paramName, paramValues)
-    }
+    this.length = this.calculateUrlLength(queryParams, reservedParams)
   }
 
   canAddParam(paramName: string, paramValue: string) {


### PR DESCRIPTION
In https://github.com/decentraland/catalyst-client/pull/75, we added the possibility to use local timestamp for pagination, instead of offset.

The problem was that we only added reserved space in the url `fromLocalTimestamp` and not `toLocalTimestamp`. So it would happen that there would be no space left in the url.

We are now making a fix for that, but we are also optimizing the way reserved space is calculated. We will be able to set a reserved space for multiple parameters, but when those parameters have a value set, then the reserved space won't be counted any more