### PR TITLE
fix: use pagination correctly in /wearables

### DIFF
--- a/test/LambdasClient.spec.ts
+++ b/test/LambdasClient.spec.ts
@@ -24,7 +24,10 @@ describe('LambdasClient', () => {
   it('When fetching only snapshots in profiles, then the result is as expected', async () => {
     const requestResult = [someResult()]
     const [ethAddress1, ethAddress2] = ['ethAddress1', 'ethAddress2']
-    const { instance: fetcher } = mockFetcherJson(`/profiles?fields=snapshots&id=${ethAddress1}&id=${ethAddress2}`, requestResult)
+    const { instance: fetcher } = mockFetcherJson(
+      `/profiles?fields=snapshots&id=${ethAddress1}&id=${ethAddress2}`,
+      requestResult
+    )
 
     const client = buildClient(URL, fetcher)
     const result = await client.fetchProfiles([ethAddress1, ethAddress2], { fields: ProfileFields.ONLY_SNAPSHOTS })
@@ -39,7 +42,7 @@ describe('LambdasClient', () => {
       pagination: { offset: 0, limit: 0, moreData: false }
     }
     const { instance: fetcher } = mockFetcherJson(
-      `/collections/wearables?textSearch=text&wearableId=id1&wearableId=id2&offset=0`,
+      `/collections/wearables?textSearch=text&wearableId=id1&wearableId=id2`,
       requestResult
     )
 

--- a/test/utils/Helper.spec.ts
+++ b/test/utils/Helper.spec.ts
@@ -129,19 +129,16 @@ describe('Helper', () => {
     const baseUrl = 'http://base.com'
     const path = '/path'
     const queryParams = { name: 'someName', values: ['value1', 'value2'] }
+    const next = `${baseUrl}${path}?someName=value1&someName=value3`
 
     const mockedFetcher: Fetcher = mock(Fetcher)
-    when(
-      mockedFetcher.fetchJson('http://base.com/path?someName=value1&someName=value2&offset=0', anything())
-    ).thenResolve({
+    when(mockedFetcher.fetchJson(`${baseUrl}${path}?someName=value1&someName=value2`, anything())).thenResolve({
       elements: [{ id: 'id1' }, { id: 'id2' }],
-      pagination: { offset: 0, limit: 2, moreData: true }
+      pagination: { limit: 2, next }
     })
-    when(
-      mockedFetcher.fetchJson('http://base.com/path?someName=value1&someName=value2&offset=2', anything())
-    ).thenResolve({
+    when(mockedFetcher.fetchJson(next, anything())).thenResolve({
       elements: [{ id: 'id2' }, { id: 'id3' }],
-      pagination: { offset: 2, limit: 2, moreData: false }
+      pagination: { limit: 2 }
     })
 
     const result = await splitAndFetchPaginated<{ id: string }>({


### PR DESCRIPTION
We've made some changes in how the `/wearables` endpoint performs pagination. Previously, we had limit/offset. Now, we have a `next` property that provides the url necessary to navigate through remaining elements.

So in this PR, we are making the changes necessary to support this new way of iterating through all elements