### PR TITLE
refactor: avoid isomorphic form data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -730,6 +730,14 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/form-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.5.0.tgz",
+      "integrity": "sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==",
+      "requires": {
+        "form-data": "*"
+      }
+    },
     "@types/isomorphic-fetch": {
       "version": "0.0.35",
       "resolved": "https://registry.npmjs.org/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz",
@@ -2617,12 +2625,12 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -3124,13 +3132,6 @@
             "is-stream": "^1.0.1"
           }
         }
-      }
-    },
-    "isomorphic-form-data": {
-      "version": "git+https://github.com/decentraland/isomorphic-form-data.git#3409301b9e0348dc30da63955fa9fdb3ac46ac3e",
-      "from": "git+https://github.com/decentraland/isomorphic-form-data.git#3409301b9e0348dc30da63955fa9fdb3ac46ac3e",
-      "requires": {
-        "form-data": "^2.3.2"
       }
     },
     "isomorphic-ws": {
@@ -4330,6 +4331,16 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
+        "form-data": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
   },
   "homepage": "https://github.com/decentraland/catalyst-client#readme",
   "dependencies": {
+    "@types/form-data": "^2.5.0",
     "async-iterator-to-array": "0.0.1",
     "dcl-catalyst-commons": "^3.0.1",
     "dcl-crypto": "^2.2.0",
-    "isomorphic-form-data": "git+https://github.com/decentraland/isomorphic-form-data.git#3409301b9e0348dc30da63955fa9fdb3ac46ac3e"
+    "form-data": "^4.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -63,7 +63,7 @@ export class ContentClient implements ContentAPI {
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    const form: FormData = areWeRunningInNode ? new FormData() : new NodeFormData()
+    const form: FormData = areWeRunningInNode ? new NodeFormData() : new FormData()
     form.append('entityId', deployData.entityId)
     addModelToFormData(deployData.authChain, form, 'authChain')
 

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -1,4 +1,3 @@
-require('isomorphic-form-data')
 import {
   Timestamp,
   Pointer,
@@ -38,6 +37,7 @@ import {
   splitValuesIntoManyQueryBuilders
 } from './utils/Helper'
 import { DeploymentData } from './utils/DeploymentBuilder'
+import NodeFormData from 'form-data'
 
 export class ContentClient implements ContentAPI {
   private static readonly CHARS_LEFT_FOR_OFFSET = 7
@@ -58,12 +58,14 @@ export class ContentClient implements ContentAPI {
   }
 
   async deployEntity(deployData: DeploymentData, fix: boolean = false, options?: RequestOptions): Promise<Timestamp> {
-    const form = new FormData()
-    form.append('entityId', deployData.entityId)
-    addModelToFormData(deployData.authChain, form, 'authChain')
-
     // Check if we are running in node or browser
     const areWeRunningInNode = isNode()
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const form: FormData = areWeRunningInNode ? new FormData() : new NodeFormData()
+    form.append('entityId', deployData.entityId)
+    addModelToFormData(deployData.authChain, form, 'authChain')
 
     const alreadyUploadedHashes = await this.hashesAlreadyOnServer(Array.from(deployData.files.keys()), options)
     for (const [fileHash, file] of deployData.files) {

--- a/src/utils/Helper.ts
+++ b/src/utils/Helper.ts
@@ -1,8 +1,6 @@
 import { Fetcher, RequestOptions } from 'dcl-catalyst-commons'
 import { RUNNING_VERSION } from './Environment'
 
-require('isomorphic-form-data')
-
 export function addModelToFormData(model: any, form: FormData, namespace = ''): FormData {
   for (const propertyName in model) {
     if (!model.hasOwnProperty(propertyName) || model[propertyName] === null || model[propertyName] === undefined)


### PR DESCRIPTION
We were using `isomorphic-form-data`, a library that only has 4 lines, to be able to use `FormData` both in Node and the browser. But we had forked it to change 2 of those 4 lines, so it was better to just do it directly on our library

This change has been tested in:
* CLI
* Explorer
* Catalyst