### PR TITLE
Set legacy query params

### DIFF
--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -240,7 +240,7 @@ export class ContentClient implements ContentAPI {
     }
 
     // Set legacy filters for get all deployments
-    if (!deploymentOptions?.sortBy || deploymentOptions.sortBy.field === SortingField.LOCAL_TIMESTAMP) {
+    if (!(deploymentOptions?.sortBy?.field === SortingField.ENTITY_TIMESTAMP)) {
       if (deploymentOptions?.filters.from) {
         const from = deploymentOptions.filters.from
         queryParams.set('fromLocalTimestamp', [`${from}`])

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -242,12 +242,12 @@ export class ContentClient implements ContentAPI {
     // Set legacy filters for get all deployments
     if (!deploymentOptions?.sortBy || deploymentOptions.sortBy.field === SortingField.LOCAL_TIMESTAMP) {
       if (deploymentOptions?.filters.from) {
-        const from = deploymentOptions?.filters.from
-        queryParams.set('fromLocalTimestamp', [from.toString()])
+        const from = deploymentOptions.filters.from
+        queryParams.set('fromLocalTimestamp', [`${from}`])
       }
       if (deploymentOptions?.filters.to) {
-        const to = deploymentOptions?.filters.to
-        queryParams.set('toLocalTimestamp', [to.toString()])
+        const to = deploymentOptions.filters.to
+        queryParams.set('toLocalTimestamp', [`${to}`])
       }
     }
 

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -240,7 +240,7 @@ export class ContentClient implements ContentAPI {
     }
 
     // Set legacy filters for get all deployments
-    if (!(deploymentOptions?.sortBy?.field === SortingField.ENTITY_TIMESTAMP)) {
+    if (deploymentOptions?.sortBy?.field !== SortingField.ENTITY_TIMESTAMP) {
       if (deploymentOptions?.filters.from) {
         const from = deploymentOptions.filters.from
         queryParams.set('fromLocalTimestamp', [`${from}`])

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -239,6 +239,18 @@ export class ContentClient implements ContentAPI {
       queryParams.set('fields', [fieldsValue])
     }
 
+    // Set legacy filters for get all deployments
+    if (!deploymentOptions?.sortBy || deploymentOptions.sortBy.field === SortingField.LOCAL_TIMESTAMP) {
+      if (deploymentOptions?.filters.from) {
+        const from = deploymentOptions?.filters.from
+        queryParams.set('fromLocalTimestamp', [from.toString()])
+      }
+      if (deploymentOptions?.filters.to) {
+        const to = deploymentOptions?.filters.to
+        queryParams.set('toLocalTimestamp', [to.toString()])
+      }
+    }
+
     let reservedParams: Map<string, number>
     let modifyQueryBasedOnResult: (result: PartialDeploymentHistory<T>, builder: QueryBuilder) => void
 


### PR DESCRIPTION
We need to send `toLocalTimestamp` and `fromLocalTimestamp` query parameters as we can't ensure that all the other catalyst have updated to the latest version that uses `from` and `to`.