### PR TITLE
Add method to build entity from the catalyst and content client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1675,9 +1675,9 @@
       }
     },
     "dcl-catalyst-commons": {
-      "version": "3.0.2-20210414172529.commit-6354154",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-3.0.2-20210414172529.commit-6354154.tgz",
-      "integrity": "sha512-EMxH5eMjhWegpVnH3V68+1DylN4ad7j6zNXLp14rOq9oN5ZfCU5crJFpAtgD5HoWMCCc7Bvs0tfXzWjkqTvS5A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-commons/-/dcl-catalyst-commons-4.0.0.tgz",
+      "integrity": "sha512-Xwf4ZlwAfhfTj8fD40+nwKh8DiEp6qTcy1OM19kdIJX1YgUMY18QMMUbPkAQHYNSsvOXOb2zZ8WAIYuwrtd8qg==",
       "requires": {
         "@types/isomorphic-fetch": "0.0.35",
         "@types/ms": "^0.7.31",

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -47,11 +47,11 @@ export class CatalystClient implements CatalystAPI {
     this.lambdasClient = new LambdasClient(this.catalystUrl + '/lambdas', fetcher)
   }
 
-  async buildDeployment(type: EntityType,
+  async buildEntity(type: EntityType,
     pointers: Pointer[],
     files: Map<string, Buffer> = new Map(),
     metadata?: EntityMetadata): Promise<DeploymentPreparationData> {
-    return this.contentClient.buildDeployment(type, pointers, files, metadata);
+    return this.contentClient.buildEntity(type, pointers, files, metadata);
   }
 
   deployEntity(deployData: DeploymentData, fix: boolean = false, options?: RequestOptions): Promise<Timestamp> {

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -18,7 +18,7 @@ import {
 } from 'dcl-catalyst-commons'
 import { Readable } from 'stream'
 import { CatalystAPI } from './CatalystAPI'
-import { DeploymentData, DeploymentPreparationData } from './utils/DeploymentBuilder'
+import { DeploymentBuilder, DeploymentData, DeploymentPreparationData } from './utils/DeploymentBuilder'
 import { getHeadersWithUserAgent, sanitizeUrl } from './utils/Helper'
 import { ContentClient, DeploymentOptions } from './ContentClient'
 import { LambdasClient } from './LambdasClient'
@@ -34,7 +34,8 @@ export class CatalystClient implements CatalystAPI {
   constructor(
     catalystUrl: string,
     origin: string, // The name or a description of the app that is using the client
-    fetcher?: Fetcher
+    fetcher?: Fetcher,
+    deploymentBuilderClass?: typeof DeploymentBuilder
   ) {
     this.catalystUrl = sanitizeUrl(catalystUrl)
     fetcher =
@@ -42,7 +43,7 @@ export class CatalystClient implements CatalystAPI {
       new Fetcher({
         headers: getHeadersWithUserAgent('catalyst-client')
       })
-    this.contentClient = new ContentClient(this.catalystUrl + '/content', origin, fetcher)
+    this.contentClient = new ContentClient(this.catalystUrl + '/content', origin, fetcher, deploymentBuilderClass)
     this.lambdasClient = new LambdasClient(this.catalystUrl + '/lambdas', fetcher)
   }
 

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -13,11 +13,12 @@ import {
   DeploymentBase,
   LegacyAuditInfo,
   RequestOptions,
-  ServerMetadata
+  ServerMetadata,
+  EntityMetadata
 } from 'dcl-catalyst-commons'
 import { Readable } from 'stream'
 import { CatalystAPI } from './CatalystAPI'
-import { DeploymentData } from './utils/DeploymentBuilder'
+import { DeploymentData, DeploymentPreparationData } from './utils/DeploymentBuilder'
 import { getHeadersWithUserAgent, sanitizeUrl } from './utils/Helper'
 import { ContentClient, DeploymentOptions } from './ContentClient'
 import { LambdasClient } from './LambdasClient'
@@ -43,6 +44,13 @@ export class CatalystClient implements CatalystAPI {
       })
     this.contentClient = new ContentClient(this.catalystUrl + '/content', origin, fetcher)
     this.lambdasClient = new LambdasClient(this.catalystUrl + '/lambdas', fetcher)
+  }
+
+  async buildDeployment(type: EntityType,
+    pointers: Pointer[],
+    files: Map<string, Buffer> = new Map(),
+    metadata?: EntityMetadata): Promise<DeploymentPreparationData> {
+    return this.contentClient.buildDeployment(type, pointers, files, metadata);
   }
 
   deployEntity(deployData: DeploymentData, fix: boolean = false, options?: RequestOptions): Promise<Timestamp> {

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -21,7 +21,8 @@ import {
   RequestOptions,
   mergeRequestOptions,
   SortingField,
-  SortingOrder
+  SortingOrder,
+  EntityMetadata
 } from 'dcl-catalyst-commons'
 import asyncToArray from 'async-iterator-to-array'
 import { Readable } from 'stream'
@@ -36,7 +37,7 @@ import {
   splitAndFetch,
   splitValuesIntoManyQueryBuilders
 } from './utils/Helper'
-import { DeploymentData } from './utils/DeploymentBuilder'
+import { DeploymentBuilder, DeploymentData, DeploymentPreparationData } from './utils/DeploymentBuilder'
 import NodeFormData from 'form-data'
 
 export class ContentClient implements ContentAPI {
@@ -55,6 +56,15 @@ export class ContentClient implements ContentAPI {
       new Fetcher({
         headers: getHeadersWithUserAgent('content-client')
       })
+  }
+
+  async buildDeployment(type: EntityType,
+    pointers: Pointer[],
+    files: Map<string, Buffer> = new Map(),
+    metadata?: EntityMetadata): Promise<DeploymentPreparationData> {
+    const result = await this.fetchContentStatus();
+    const timestamp = result.currentTime;
+    return DeploymentBuilder.buildEntity(type, pointers, files, metadata, timestamp);
   }
 
   async deployEntity(deployData: DeploymentData, fix: boolean = false, options?: RequestOptions): Promise<Timestamp> {
@@ -430,7 +440,7 @@ export class DeploymentFields<T extends Partial<Deployment>> {
     'metadata'
   ])
 
-  private constructor(private readonly fields: string[]) {}
+  private constructor(private readonly fields: string[]) { }
 
   getFields(): string {
     return this.fields.join(',')

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -61,7 +61,7 @@ export class ContentClient implements ContentAPI {
     this.deploymentBuilderClass = deploymentBuilderClass ?? DeploymentBuilder
   }
 
-  async buildDeployment(type: EntityType,
+  async buildEntity(type: EntityType,
     pointers: Pointer[],
     files: Map<string, Buffer> = new Map(),
     metadata?: EntityMetadata): Promise<DeploymentPreparationData> {

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -44,11 +44,13 @@ export class ContentClient implements ContentAPI {
   private static readonly CHARS_LEFT_FOR_OFFSET = 7
   private readonly contentUrl: string
   private readonly fetcher: Fetcher
+  private readonly deploymentBuilderClass: typeof DeploymentBuilder
 
   constructor(
     contentUrl: string,
     private readonly origin: string, // The name or a description of the app that is using the client
-    fetcher?: Fetcher
+    fetcher?: Fetcher,
+    deploymentBuilderClass?: typeof DeploymentBuilder
   ) {
     this.contentUrl = sanitizeUrl(contentUrl)
     this.fetcher =
@@ -56,6 +58,7 @@ export class ContentClient implements ContentAPI {
       new Fetcher({
         headers: getHeadersWithUserAgent('content-client')
       })
+    this.deploymentBuilderClass = deploymentBuilderClass ?? DeploymentBuilder
   }
 
   async buildDeployment(type: EntityType,
@@ -64,7 +67,7 @@ export class ContentClient implements ContentAPI {
     metadata?: EntityMetadata): Promise<DeploymentPreparationData> {
     const result = await this.fetchContentStatus();
     const timestamp = result.currentTime;
-    return DeploymentBuilder.buildEntity(type, pointers, files, metadata, timestamp);
+    return this.deploymentBuilderClass.buildEntity(type, pointers, files, metadata, timestamp);
   }
 
   async deployEntity(deployData: DeploymentData, fix: boolean = false, options?: RequestOptions): Promise<Timestamp> {

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -23,6 +23,40 @@ const expect = chai.expect
 describe('ContentClient', () => {
   const URL = 'https://url.com'
 
+  describe("When calling buildDeployment", () => {
+    let mocked;
+    let fetcher;
+    const currentTime = 100;
+
+    beforeEach(async () => {
+      ({ mock: mocked, instance: fetcher } = mockFetcherJson('/status', { currentTime }))
+
+      const client = buildClient(URL, fetcher)
+
+      const type = EntityType.PROFILE;
+      const pointers = ["p1"];
+      const files = new Map();
+      const metadata = {};
+
+      await client.buildDeployment(type, pointers, files, metadata)
+    })
+
+    it("should fetch the status", () => {
+      verify(mocked.fetchJson(URL + '/status', anything())).once()
+    })
+  })
+
+  it('When building a deployment, then the deployment is built', async () => {
+    const requestResult: Entity[] = [someEntity()]
+    const pointer = 'P'
+    const { instance: fetcher } = mockFetcherJson(`/entities/profile?pointer=${pointer}`, requestResult)
+
+    const client = buildClient(URL, fetcher)
+    const result = await client.fetchEntitiesByPointers(EntityType.PROFILE, [pointer])
+
+    expect(result).to.deep.equal(requestResult)
+  })
+
   it('When fetching by pointers, if none is set, then an error is thrown', () => {
     const { mock: mocked, instance: fetcher } = mockFetcherJson()
 

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -16,6 +16,7 @@ import {
 } from 'dcl-catalyst-commons'
 import { DeploymentWithMetadataContentAndPointers } from 'ContentAPI'
 import { Headers } from 'node-fetch'
+import { DeploymentBuilder } from 'utils'
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -31,12 +32,16 @@ describe('ContentClient', () => {
     beforeEach(async () => {
       ({ mock: mocked, instance: fetcher } = mockFetcherJson('/status', { currentTime }))
 
-      const client = buildClient(URL, fetcher)
+      const deploymentBuilderClassMock: typeof DeploymentBuilder = mock<typeof DeploymentBuilder>(DeploymentBuilder);
 
       const type = EntityType.PROFILE;
       const pointers = ["p1"];
       const files = new Map();
       const metadata = {};
+
+      when(deploymentBuilderClassMock.buildEntity(type, pointers, files, metadata, currentTime)).thenResolve()
+
+      const client = buildClient(URL, fetcher, instance(deploymentBuilderClassMock))
 
       await client.buildDeployment(type, pointers, files, metadata)
     })
@@ -422,7 +427,7 @@ describe('ContentClient', () => {
     return { mock: mockedFetcher, instance: instance(mockedFetcher) }
   }
 
-  function buildClient(URL: string, fetcher?: Fetcher) {
-    return new ContentClient(URL, 'origin', fetcher)
+  function buildClient(URL: string, fetcher?: Fetcher, deploymentBuilderClass?: typeof DeploymentBuilder) {
+    return new ContentClient(URL, 'origin', fetcher, deploymentBuilderClass)
   }
 })

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -27,27 +27,30 @@ describe('ContentClient', () => {
   describe("When calling buildDeployment", () => {
     let mocked;
     let fetcher;
+    const type = EntityType.PROFILE;
+    const pointers = ["p1"];
+    const files = new Map();
+    const metadata = {};
     const currentTime = 100;
+    let deploymentBuilderClassMock: typeof DeploymentBuilder;
 
     beforeEach(async () => {
       ({ mock: mocked, instance: fetcher } = mockFetcherJson('/status', { currentTime }))
 
-      const deploymentBuilderClassMock: typeof DeploymentBuilder = mock<typeof DeploymentBuilder>(DeploymentBuilder);
-
-      const type = EntityType.PROFILE;
-      const pointers = ["p1"];
-      const files = new Map();
-      const metadata = {};
+      deploymentBuilderClassMock = mock<typeof DeploymentBuilder>(DeploymentBuilder);
 
       when(deploymentBuilderClassMock.buildEntity(type, pointers, files, metadata, currentTime)).thenResolve()
 
       const client = buildClient(URL, fetcher, instance(deploymentBuilderClassMock))
-
-      await client.buildDeployment(type, pointers, files, metadata)
+      await client.buildEntity(type, pointers, files, metadata)
     })
 
     it("should fetch the status", () => {
       verify(mocked.fetchJson(URL + '/status', anything())).once()
+    })
+
+    it("should call the deployer builder with the expected parameters", () => {
+      verify(deploymentBuilderClassMock.buildEntity(type, pointers, files, metadata, currentTime)).once()
     })
   })
 


### PR DESCRIPTION
Motivation:
Currently, the `DeploymentBuilder` is calling `worldtimeapi` when there isn't a timestamp provided, this is a problem since the API is unreliable (returns 503 more often than expected). Thus we're switching to depend on the timestamp provided by the catalyst peer that the client is connected to. 
Also, the DeploymentBuilder accepts a timestamp that might come with problems since the user can taint the information, the proposal is that in the future we stop exposing `DeploymentBuilder` and let the users only build deployments through the new exposed method in the clients

In this PR:
- Add method to build a deployment from the Catalyst client
- Add method to build a deployment from the Content client

Fixes #19 