### PR TITLE
Make parameters from buildEntity an object

### DIFF
--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -13,14 +13,13 @@ import {
   DeploymentBase,
   LegacyAuditInfo,
   RequestOptions,
-  ServerMetadata,
-  EntityMetadata
+  ServerMetadata
 } from 'dcl-catalyst-commons'
 import { Readable } from 'stream'
 import { CatalystAPI } from './CatalystAPI'
 import { DeploymentBuilder, DeploymentData, DeploymentPreparationData } from './utils/DeploymentBuilder'
 import { getHeadersWithUserAgent, sanitizeUrl } from './utils/Helper'
-import { ContentClient, DeploymentOptions } from './ContentClient'
+import { BuildEntityOptions, ContentClient, DeploymentOptions } from './ContentClient'
 import { LambdasClient } from './LambdasClient'
 import { DeploymentWithMetadataContentAndPointers } from './ContentAPI'
 import { WearablesFilters, OwnedWearables, ProfileOptions } from './LambdasAPI'
@@ -47,11 +46,8 @@ export class CatalystClient implements CatalystAPI {
     this.lambdasClient = new LambdasClient(this.catalystUrl + '/lambdas', fetcher)
   }
 
-  async buildEntity(type: EntityType,
-    pointers: Pointer[],
-    files: Map<string, Buffer> = new Map(),
-    metadata?: EntityMetadata): Promise<DeploymentPreparationData> {
-    return this.contentClient.buildEntity(type, pointers, files, metadata);
+  async buildEntity({ type, pointers, files, metadata }: BuildEntityOptions): Promise<DeploymentPreparationData> {
+    return this.contentClient.buildEntity({ type, pointers, files, metadata });
   }
 
   deployEntity(deployData: DeploymentData, fix: boolean = false, options?: RequestOptions): Promise<Timestamp> {

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -15,10 +15,13 @@ import {
   RequestOptions
 } from 'dcl-catalyst-commons'
 import { Readable } from 'stream'
-import { DeploymentData } from './utils/DeploymentBuilder'
-import { DeploymentOptions } from './ContentClient'
+import { DeploymentData, DeploymentPreparationData } from './utils/DeploymentBuilder'
+import { BuildEntityOptions, DeploymentOptions } from './ContentClient'
 
 export interface ContentAPI {
+  /** Build entities */
+  buildEntity({ type, pointers, files, metadata }: BuildEntityOptions): Promise<DeploymentPreparationData>
+
   /** Retrieve / Download */
   fetchEntitiesByPointers(type: EntityType, pointers: Pointer[], options?: RequestOptions): Promise<Entity[]>
   fetchEntitiesByIds(type: EntityType, ids: EntityId[], options?: RequestOptions): Promise<Entity[]>

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -61,13 +61,11 @@ export class ContentClient implements ContentAPI {
     this.deploymentBuilderClass = deploymentBuilderClass ?? DeploymentBuilder
   }
 
-  async buildEntity(type: EntityType,
-    pointers: Pointer[],
-    files: Map<string, Buffer> = new Map(),
-    metadata?: EntityMetadata): Promise<DeploymentPreparationData> {
-    const result = await this.fetchContentStatus();
-    const timestamp = result.currentTime;
-    return this.deploymentBuilderClass.buildEntity(type, pointers, files, metadata, timestamp);
+  async buildEntity({ type, pointers, files, metadata }: BuildEntityOptions): Promise<DeploymentPreparationData> {
+    files = files || new Map()
+    const result = await this.fetchContentStatus()
+    const timestamp = result.currentTime
+    return this.deploymentBuilderClass.buildEntity(type, pointers, files, metadata, timestamp)
   }
 
   async deployEntity(deployData: DeploymentData, fix: boolean = false, options?: RequestOptions): Promise<Timestamp> {
@@ -425,6 +423,13 @@ export type DeploymentOptions<T> = {
   sortBy?: DeploymentSorting
   fields?: DeploymentFields<T>
   errorListener?: (errorMessage: string) => void
+}
+
+export interface BuildEntityOptions {
+  type: EntityType
+  pointers: Pointer[]
+  files?: Map<string, Buffer>
+  metadata?: EntityMetadata
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -1,6 +1,6 @@
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import { mock, instance, when, anything, verify } from 'ts-mockito'
+import { mock, instance, when, anything, verify, deepEqual } from 'ts-mockito'
 import { ContentClient, DeploymentFields } from 'ContentClient'
 import {
   EntityType,
@@ -29,7 +29,7 @@ describe('ContentClient', () => {
     let fetcher;
     const type = EntityType.PROFILE;
     const pointers = ["p1"];
-    const files = new Map();
+    const files = undefined;
     const metadata = {};
     const currentTime = 100;
     let deploymentBuilderClassMock: typeof DeploymentBuilder;
@@ -42,7 +42,7 @@ describe('ContentClient', () => {
       when(deploymentBuilderClassMock.buildEntity(type, pointers, files, metadata, currentTime)).thenResolve()
 
       const client = buildClient(URL, fetcher, instance(deploymentBuilderClassMock))
-      await client.buildEntity(type, pointers, files, metadata)
+      await client.buildEntity({ type, pointers, files, metadata })
     })
 
     it("should fetch the status", () => {
@@ -50,7 +50,7 @@ describe('ContentClient', () => {
     })
 
     it("should call the deployer builder with the expected parameters", () => {
-      verify(deploymentBuilderClassMock.buildEntity(type, pointers, files, metadata, currentTime)).once()
+      verify(deploymentBuilderClassMock.buildEntity(type, pointers, deepEqual(new Map()), metadata, currentTime)).once()
     })
   })
 


### PR DESCRIPTION
In this PR:
- Add the `buildEntity` method to the API
- Make the parameters an object, for futureproof