### PR TITLE
refactor: remove unused functions from shared client to lower complexity

### DIFF
--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -44,6 +44,11 @@ export class CatalystClient implements CatalystAPI {
     return this.contentClient.buildEntityWithoutNewFiles(options)
   }
 
+  /** @deprecated use deploy instead */
+  deployEntity(deployData: DeploymentData, fix: boolean = false, options?: RequestOptions): Promise<number> {
+    return this.contentClient.deployEntity(deployData, fix, options)
+  }
+
   deploy(deployData: DeploymentData, options?: RequestOptions): Promise<unknown> {
     return this.contentClient.deploy(deployData, options)
   }

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -44,11 +44,6 @@ export class CatalystClient implements CatalystAPI {
     return this.contentClient.buildEntityWithoutNewFiles(options)
   }
 
-  /** @deprecated use deploy instead */
-  deployEntity(deployData: DeploymentData, fix: boolean = false, options?: RequestOptions): Promise<number> {
-    return this.contentClient.deployEntity(deployData, fix, options)
-  }
-
   deploy(deployData: DeploymentData, options?: RequestOptions): Promise<unknown> {
     return this.contentClient.deploy(deployData, options)
   }

--- a/src/CatalystClient.ts
+++ b/src/CatalystClient.ts
@@ -1,13 +1,5 @@
-import { Entity, EntityType } from '@dcl/schemas'
-import {
-  AuditInfo,
-  AvailableContentResult,
-  Fetcher,
-  HealthStatus,
-  RequestOptions,
-  ServerStatus
-} from 'dcl-catalyst-commons'
-import { Writable } from 'stream'
+import { Entity } from '@dcl/schemas'
+import { Fetcher, HealthStatus, RequestOptions } from 'dcl-catalyst-commons'
 import { CatalystAPI } from './CatalystAPI'
 import { BuildEntityOptions, BuildEntityWithoutFilesOptions, ContentClient } from './ContentClient'
 import { EmotesFilters, OwnedItems, ServerMetadata, WearablesFilters } from './LambdasAPI'
@@ -73,24 +65,8 @@ export class CatalystClient implements CatalystAPI {
     return this.contentClient.fetchEntityById(id, options)
   }
 
-  fetchAuditInfo(type: EntityType, id: string, options?: RequestOptions): Promise<AuditInfo> {
-    return this.contentClient.fetchAuditInfo(type, id, options)
-  }
-
-  fetchContentStatus(options?: RequestOptions): Promise<ServerStatus> {
-    return this.contentClient.fetchContentStatus(options)
-  }
-
-  isContentAvailable(cids: string[], options?: RequestOptions): Promise<AvailableContentResult> {
-    return this.contentClient.isContentAvailable(cids, options)
-  }
-
   downloadContent(contentHash: string, options?: RequestOptions): Promise<Buffer> {
     return this.contentClient.downloadContent(contentHash, options)
-  }
-
-  pipeContent(contentHash: string, writeTo: Writable, options?: RequestOptions): Promise<Map<string, string>> {
-    return this.contentClient.pipeContent(contentHash, writeTo, options)
   }
 
   fetchProfiles(ethAddresses: string[], options?: RequestOptions): Promise<any[]> {

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -1,6 +1,5 @@
-import { AuthChain, Entity, EntityType } from '@dcl/schemas'
-import { RequestOptions, ServerStatus } from 'dcl-catalyst-commons'
-import type { Writable } from 'stream'
+import { AuthChain, Entity } from '@dcl/schemas'
+import { RequestOptions } from 'dcl-catalyst-commons'
 import { BuildEntityOptions, BuildEntityWithoutFilesOptions } from './ContentClient'
 import { DeploymentData, DeploymentPreparationData } from './utils/DeploymentBuilder'
 
@@ -28,16 +27,7 @@ export interface ContentAPI {
   fetchEntitiesByPointers(pointers: string[], options?: RequestOptions): Promise<Entity[]>
   fetchEntitiesByIds(ids: string[], options?: RequestOptions): Promise<Entity[]>
   fetchEntityById(id: string, options?: RequestOptions): Promise<Entity>
-  fetchAuditInfo(type: EntityType, id: string, options?: RequestOptions): Promise<EntityAuditInfoResponse>
-  fetchContentStatus(options?: RequestOptions): Promise<ServerStatus>
   downloadContent(contentHash: string, options?: RequestOptions): Promise<Buffer>
-  isContentAvailable(cids: string[], options?: RequestOptions): Promise<AvailableContentResult>
-
-  /**
-   * @deprecated pipeContent only works in Node.js like environments.
-   * Move this to lambdas server https://github.com/decentraland/catalyst/issues/1119
-   */
-  pipeContent(contentHash: string, writeTo: Writable, options?: RequestOptions): Promise<Map<string, string>>
 
   /** @deprecated use deploy instead */
   deployEntity(deployData: DeploymentData, fix?: boolean, options?: RequestOptions): Promise<number>

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -29,9 +29,6 @@ export interface ContentAPI {
   fetchEntityById(id: string, options?: RequestOptions): Promise<Entity>
   downloadContent(contentHash: string, options?: RequestOptions): Promise<Buffer>
 
-  /** @deprecated use deploy instead */
-  deployEntity(deployData: DeploymentData, fix?: boolean, options?: RequestOptions): Promise<number>
-
   /**
    * Deploys an entity to the content server.
    */

--- a/src/ContentAPI.ts
+++ b/src/ContentAPI.ts
@@ -29,6 +29,9 @@ export interface ContentAPI {
   fetchEntityById(id: string, options?: RequestOptions): Promise<Entity>
   downloadContent(contentHash: string, options?: RequestOptions): Promise<Buffer>
 
+  /** @deprecated use deploy instead */
+  deployEntity(deployData: DeploymentData, fix?: boolean, options?: RequestOptions): Promise<number>
+
   /**
    * Deploys an entity to the content server.
    */

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -86,11 +86,6 @@ export class ContentClient implements ContentAPI {
     return form
   }
 
-  async deployEntity(deployData: DeploymentData, _fix: boolean = false, options?: RequestOptions): Promise<number> {
-    const { creationTimestamp } = (await this.deploy(deployData, options)) as { creationTimestamp: number }
-    return creationTimestamp
-  }
-
   async deploy(deployData: DeploymentData, options?: RequestOptions): Promise<unknown> {
     const form = await this.buildEntityFormDataForDeployment(deployData, options)
 

--- a/src/ContentClient.ts
+++ b/src/ContentClient.ts
@@ -1,6 +1,6 @@
 import { hashV0, hashV1 } from '@dcl/hashing'
 import { Entity, EntityType } from '@dcl/schemas'
-import { Fetcher, mergeRequestOptions, RequestOptions, retry } from 'dcl-catalyst-commons'
+import { Fetcher, RequestOptions, retry } from 'dcl-catalyst-commons'
 import FormData from 'form-data'
 import { AvailableContentResult, ContentAPI } from './ContentAPI'
 import { DeploymentBuilder, DeploymentData, DeploymentPreparationData } from './utils/DeploymentBuilder'
@@ -89,24 +89,24 @@ export class ContentClient implements ContentAPI {
   async deploy(deployData: DeploymentData, options?: RequestOptions): Promise<unknown> {
     const form = await this.buildEntityFormDataForDeployment(deployData, options)
 
-    const requestOptions = mergeRequestOptions(options ? options : {}, {
-      body: form as any,
-      method: 'POST'
-    })
-
-    return await this.fetcher.fetch(`${this.contentUrl}/entities`, requestOptions)
+    return await this.fetcher.fetch(`${this.contentUrl}/entities`, { ...options, body: form as any, method: 'POST' })
   }
 
   async fetchEntitiesByPointers(pointers: string[], options?: RequestOptions): Promise<Entity[]> {
     if (pointers.length === 0) {
       return Promise.reject(`You must set at least one pointer.`)
     }
-    const requestOptions = mergeRequestOptions(options ? options : {}, {
-      body: JSON.stringify({ pointers: pointers }),
-      method: 'POST'
-    })
 
-    return (await this.fetcher.fetch(`${this.contentUrl}/entities/active`, requestOptions)).json()
+    return (
+      await this.fetcher.fetch(`${this.contentUrl}/entities/active`, {
+        ...options,
+        body: JSON.stringify({ pointers }),
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      })
+    ).json()
   }
 
   async fetchEntitiesByIds(ids: string[], options?: RequestOptions): Promise<Entity[]> {
@@ -114,12 +114,13 @@ export class ContentClient implements ContentAPI {
       return Promise.reject(`You must set at least one id.`)
     }
 
-    const requestOptions = mergeRequestOptions(options ? options : {}, {
-      body: JSON.stringify({ ids: ids }),
-      method: 'POST'
-    })
-
-    return (await this.fetcher.fetch(`${this.contentUrl}/entities/active`, requestOptions)).json()
+    return (
+      await this.fetcher.fetch(`${this.contentUrl}/entities/active`, {
+        ...options,
+        body: JSON.stringify({ ids: ids }),
+        method: 'POST'
+      })
+    ).json()
   }
 
   async fetchEntityById(id: string, options?: RequestOptions): Promise<Entity> {

--- a/test/ContentClient.E2E.spec.ts
+++ b/test/ContentClient.E2E.spec.ts
@@ -50,6 +50,6 @@ runServerBasedE2ETest('test client post', ({ components }) => {
     files.set('QmA', new Uint8Array([111, 112, 113]))
     files.set('QmB', Buffer.from('asd', 'utf-8'))
 
-    await client.deployEntity({ authChain: [], entityId: 'QmENTITY', files })
+    await client.deploy({ authChain: [], entityId: 'QmENTITY', files })
   })
 })

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -2,7 +2,6 @@ import { hashV0 } from '@dcl/hashing'
 import { Entity, EntityType } from '@dcl/schemas'
 import { Fetcher } from 'dcl-catalyst-commons'
 import { Headers } from 'node-fetch'
-import { Readable } from 'stream'
 import { anything, deepEqual, instance, mock, verify, when } from 'ts-mockito'
 import { AvailableContentResult } from '../src/ContentAPI'
 import { ContentClient } from '../src/ContentClient'
@@ -285,44 +284,6 @@ describe('ContentClient', () => {
 
     await expect(client.isContentAvailable([])).rejects.toEqual(`You must set at least one cid.`)
     verify(mocked.fetchJson(anything())).never()
-  })
-
-  it('When a fetch is piped without headers then none is returned', async () => {
-    const contentHash = 'abc123'
-    const mockedResponse = instance(mock<Readable>())
-    const { instance: fetcher } = mockPipeFetcher(new Headers())
-    const client = buildClient(URL, fetcher)
-
-    const result = await client.pipeContent(contentHash, mockedResponse)
-
-    expect(result).toEqual(new Map())
-  })
-
-  it('When a fetch is piped with a non recognized header then none is returned', async () => {
-    const contentHash = 'abc123'
-    const mockedResponse = instance(mock<Readable>())
-    const headers: Headers = new Headers()
-    headers.set('invalid', 'val')
-    const { instance: fetcher } = mockPipeFetcher(headers)
-    const client = buildClient(URL, fetcher)
-
-    const result = await client.pipeContent(contentHash, mockedResponse)
-
-    expect(result).toEqual(new Map())
-  })
-
-  it('When a fetch is piped then only sanitized headers of the response are returned', async () => {
-    const contentHash = 'abc123'
-    const mockedResponse = instance(mock<Readable>())
-    const headers: Headers = new Headers()
-    headers.set('invalid', 'val')
-    headers.set('content-length', '200')
-    const { instance: fetcher } = mockPipeFetcher(headers)
-    const client = buildClient(URL, fetcher)
-
-    const result = await client.pipeContent(contentHash, mockedResponse)
-
-    expect(result.has('Content-Length')).toBe(true)
   })
 
   function someEntity(): Entity {


### PR DESCRIPTION
This PR will remove the unused functions from the shared catalyst client to lower complexity on the client side.

To address what needs to be removed here we used CodeSearch. Basically, we searched for those functions only being used on `catalyst/lambdas server` and moved their implementation to that project instead of having them in the shared client.

Since I don't have access to GitHub CodeSearch yet I would appreciate to double-check that the functions removed in this PR are only being used by this lambdas server mentioned above.


Off-note: the tests removed will be added to `catalyst` where the implementations will be.

[Issue (#1119)](https://github.com/decentraland/catalyst/issues/1119)