### PR TITLE
fix: build export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,4 +105,6 @@ dist
 
 *.DS_Store
 
-.vscode/
+.vscode
+
+src/package.json

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,5 @@ dist
 .tern-port
 
 *.DS_Store
+
+.vscode/

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "ethers": "6.2.3"
   },
   "files": [
-    "package.json"
+    "package.json",
+    "dist"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-development",
   "commit": "Unknown",
   "description": "A client to query and perform changes on Decentraland's catalyst servers",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
     "prebuild": "rm -rf dist",

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.0.0-development",
   "commit": "Unknown",
   "description": "A client to query and perform changes on Decentraland's catalyst servers",
-  "main": "dist/src/index.js",
-  "typings": "./dist/index.d.ts",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "prebuild": "rm -rf dist",
     "generate:snapshots": "ts-node -T scripts/generate-snapshots.ts",
-    "build": "tsc --project tsconfig-build.json && yarn generate:snapshots",
+    "build": "cp package.json ./src/package.json && tsc --project tsconfig.json && yarn generate:snapshots",
     "prewatch": "rm -rf dist",
     "watch": "tsc --watch --project tsconfig-build.json",
     "test": "jest --forceExit --detectOpenHandles --coverage --verbose",
@@ -73,5 +73,8 @@
   },
   "optionalDependencies": {
     "ethers": "6.2.3"
-  }
+  },
+  "files": [
+    "package.json"
+  ]
 }

--- a/src/client/utils/Helper.ts
+++ b/src/client/utils/Helper.ts
@@ -1,7 +1,7 @@
 import { createFetchComponent } from '@well-known-components/fetch-component'
 import { IFetchComponent, RequestOptions } from '@well-known-components/interfaces'
 import type FormData from 'form-data'
-import { commit, version } from './../../../package.json'
+import { commit, version } from './../../package.json'
 
 export function getCurrentVersion(): string {
   return version || commit || 'Unknown'

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "baseUrl": "/dist/src/",
-    "esModuleInterop": true
-  },
-  "include": ["./src"]
-}

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "baseUrl": "/dist/src/",
     "esModuleInterop": true
   },
   "include": ["./src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
+    "baseUrl": "/dist/src/",
     "outDir": "dist",
     "module": "commonjs",
     "target": "es2018",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "/dist/src/",
+    "baseUrl": "src",
     "outDir": "dist",
     "module": "commonjs",
     "target": "es2018",
@@ -8,7 +8,9 @@
       "es2018",
       "DOM"
     ],
-    "types": [],
+    "types": [
+      "node"
+    ],
     "sourceMap": true,
     "moduleResolution": "node16",
     "forceConsistentCasingInFileNames": true,
@@ -17,18 +19,18 @@
     "noImplicitThis": true,
     "noImplicitAny": false,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,
-    "plugins": [
-      {
-        "name": "tslint-language-service"
-      }
-    ],
     "declaration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "declarationMap": true
   },
   "include": [
     "src"
+  ],
+  "plugins": [
+    {
+      "name": "tslint-language-service"
+    }
   ]
 }


### PR DESCRIPTION
This library package is being published wrongly because it adds the src directory to the build output. Therefore, this PR updates the library build output to avoid creating the `src` directory in build the output, so the clients can import the library like `import { buildEntity } from 'dcl-catalyst-client/dist/client/utils/DeploymentBuilder'` instead of `import { buildEntity } from 'dcl-catalyst-client/dist/src/client/utils/DeploymentBuilder'`

Before the update:
```
.
|____package.json
|____src
| |____types.js
| |____types.js.map
| |____types.d.ts
| |____contracts
| | |____abi.js.map
| | |____types.js
| | |____types.js.map
| | |____types.d.ts
| | |____index.js
| | |____index.js.map
| | |____abi.d.ts
| | |____index.d.ts
| | |____abi.js
| |____index.js
| |____index.js.map
| |____contracts-snapshots
| | |____data.js.map
| | |____index.js
| | |____data.d.ts
| | |____data.js
| | |____index.js.map
| | |____index.d.ts
| |____index.d.ts
| |____client
| | |____LambdasClient.d.ts
| | |____ContentClient.d.ts
| | |____types.js
| | |____ContentClient.js.map
| | |____types.js.map
| | |____CatalystClient.d.ts
| | |____types.d.ts
| | |____utils
| | | |____DeploymentBuilder.d.ts
| | | |____fetcher.js.map
| | | |____DeploymentBuilder.js.map
| | | |____fetcher.d.ts
| | | |____Helper.js.map
| | | |____fetcher.js
| | | |____retry.js.map
| | | |____Helper.d.ts
| | | |____retry.js
| | | |____retry.d.ts
| | | |____Helper.js
| | | |____DeploymentBuilder.js
| | |____ContentClient.js
| | |____CatalystClient.js
| | |____LambdasClient.js.map
| | |____LambdasClient.js
| | |____CatalystClient.js.map
```
After the update:
```
.
|____types.js
|____types.js.map
|____types.d.ts
|____contracts
| |____abi.js.map
| |____abi.d.ts.map
| |____types.js
| |____types.js.map
| |____types.d.ts
| |____index.js
| |____index.js.map
| |____abi.d.ts
| |____types.d.ts.map
| |____index.d.ts
| |____abi.js
| |____index.d.ts.map
|____index.js
|____package.json
|____index.js.map
|____types.d.ts.map
|____contracts-snapshots
| |____data.js.map
| |____data.d.ts.map
| |____index.js
| |____data.d.ts
| |____data.js
| |____index.js.map
| |____index.d.ts
| |____index.d.ts.map
|____index.d.ts
|____client
| |____LambdasClient.d.ts
| |____ContentClient.d.ts
| |____types.js
| |____ContentClient.js.map
| |____types.js.map
| |____CatalystClient.d.ts.map
| |____CatalystClient.d.ts
| |____types.d.ts
| |____utils
| | |____DeploymentBuilder.d.ts
| | |____fetcher.d.ts.map
| | |____DeploymentBuilder.d.ts.map
| | |____Helper.d.ts.map
| | |____fetcher.js.map
| | |____DeploymentBuilder.js.map
| | |____fetcher.d.ts
| | |____retry.d.ts.map
| | |____Helper.js.map
| | |____fetcher.js
| | |____retry.js.map
| | |____Helper.d.ts
| | |____retry.js
| | |____retry.d.ts
| | |____Helper.js
| | |____DeploymentBuilder.js
| |____ContentClient.js
| |____ContentClient.d.ts.map
| |____CatalystClient.js
| |____LambdasClient.js.map
| |____LambdasClient.js
| |____LambdasClient.d.ts.map
| |____CatalystClient.js.map
| |____types.d.ts.map
|____index.d.ts.map
```