### PR TITLE
chore: remove default request headers

### DIFF
--- a/src/client/ContentClient.ts
+++ b/src/client/ContentClient.ts
@@ -4,7 +4,6 @@ import { IFetchComponent, RequestOptions } from '@well-known-components/interfac
 import FormData from 'form-data'
 import { ClientOptions, DeploymentData } from './types'
 import { addModelToFormData, isNode, mergeRequestOptions, sanitizeUrl, splitAndFetch } from './utils/Helper'
-import { withDefaultHeadersInjection } from './utils/fetcher'
 import { retry } from './utils/retry'
 
 function arrayBufferFrom(value: Buffer | Uint8Array) {
@@ -64,8 +63,8 @@ export async function downloadContent(
 }
 
 export function createContentClient(options: ClientOptions): ContentClient {
+  const { fetcher } = options
   const contentUrl = sanitizeUrl(options.url)
-  const fetcher = withDefaultHeadersInjection(options.fetcher)
 
   async function buildEntityFormDataForDeployment(
     deployData: DeploymentData,

--- a/src/client/LambdasClient.ts
+++ b/src/client/LambdasClient.ts
@@ -1,17 +1,16 @@
 import { sanitizeUrl } from './utils/Helper'
 import { ClientOptions } from './types'
-import { withDefaultHeadersInjection, CustomClient } from './utils/fetcher'
+import { CustomClient } from './utils/fetcher'
 import * as client from './specs/lambdas-client'
 
 export type LambdasClient = ReturnType<typeof createLambdasClient>
 
 export function createLambdasClient(options: ClientOptions) {
   const lambdasUrl = sanitizeUrl(options.url)
-  const fetcher = withDefaultHeadersInjection(options.fetcher)
 
   function wrap<T extends (...args: any) => CustomClient<any>>(f: T) {
     return (...args: Parameters<T>): ReturnType<ReturnType<T>> => {
-      return f(...(args as any))(lambdasUrl, fetcher) as any
+      return f(...(args as any))(lambdasUrl, options.fetcher) as any
     }
   }
 

--- a/src/client/utils/fetcher.ts
+++ b/src/client/utils/fetcher.ts
@@ -1,18 +1,4 @@
-import { IFetchComponent, RequestOptions } from '@well-known-components/interfaces'
-import * as nodeFetch from 'node-fetch'
-import { getCurrentVersion, mergeRequestOptions } from './Helper'
-
-export function withDefaultHeadersInjection(fetcher: IFetchComponent): IFetchComponent {
-  return {
-    fetch: async (url: nodeFetch.RequestInfo, init?: RequestOptions): Promise<nodeFetch.Response> => {
-      const optionsWithInjectedClientAgent = mergeRequestOptions(init ? init : {}, {
-        headers: { 'X-Requested-With': getCurrentVersion() }
-      })
-
-      return await fetcher.fetch(url, optionsWithInjectedClientAgent)
-    }
-  }
-}
+import { IFetchComponent } from '@well-known-components/interfaces'
 
 type Context = {
   url: string

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -95,24 +95,6 @@ describe('ContentClient', () => {
     expect(result).toEqual(requestResult)
   })
 
-  it('When fetching by pointers, then the X-Requested-With default header is included', async () => {
-    const requestResult: Entity[] = [someEntity()]
-    const pointer = 'P'
-    const fetcher = createFetchComponent()
-
-    fetcher.fetch = jest.fn().mockResolvedValueOnce({ json: () => requestResult })
-
-    const client = buildClient(URL, fetcher)
-    await client.fetchEntitiesByPointers([pointer])
-
-    expect(fetcher.fetch).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        headers: { 'X-Requested-With': getCurrentVersion(), 'Content-Type': 'application/json' }
-      })
-    )
-  })
-
   it('When fetching by ids, if none is set, then an error is thrown', async () => {
     const fetcher = createFetchComponent()
     fetcher.fetch = jest.fn().mockResolvedValueOnce({ json: () => [] })
@@ -137,24 +119,6 @@ describe('ContentClient', () => {
     expect(result).toEqual(requestResult)
   })
 
-  it('When fetching by ids, then the X-Requested-With default header is included', async () => {
-    const requestResult: Entity[] = [someEntity()]
-    const id = 'Id'
-
-    const fetcher = createFetchComponent()
-    fetcher.fetch = jest.fn().mockResolvedValueOnce({ json: () => requestResult })
-    const client = buildClient(URL, fetcher)
-
-    await client.fetchEntitiesByIds([id])
-
-    expect(fetcher.fetch).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        headers: { 'X-Requested-With': getCurrentVersion(), 'Content-Type': 'application/json' }
-      })
-    )
-  })
-
   it('When fetching by id, if there are no results, then an error is thrown', async () => {
     const id = 'Id'
 
@@ -177,25 +141,6 @@ describe('ContentClient', () => {
     const result = await client.fetchEntityById(id)
 
     expect(result).toEqual(entity)
-  })
-
-  it('When fetching by id, then the X-Requested-With default header is included', async () => {
-    const entity = someEntity()
-    const requestResult: Entity[] = [entity]
-    const id = 'Id'
-
-    const fetcher = createFetchComponent()
-    fetcher.fetch = jest.fn().mockResolvedValueOnce({ json: () => requestResult })
-    const client = buildClient(URL, fetcher)
-
-    await client.fetchEntityById(id)
-
-    expect(fetcher.fetch).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        headers: { 'X-Requested-With': getCurrentVersion(), 'Content-Type': 'application/json' }
-      })
-    )
   })
 
   it('When a file is downloaded, then the client retries if the downloaded file is not as expected', async () => {
@@ -237,27 +182,6 @@ describe('ContentClient', () => {
     expect(fetcher.fetch).toHaveBeenNthCalledWith(2, `${URL}/contents/${fileHash}`, expect.anything())
   })
 
-  it('When a file is downloaded, then the X-Requested-With default header is included', async () => {
-    const failBuffer = Buffer.from('Fail')
-    const realBuffer = Buffer.from('Real')
-    const fileHash = await hashV0(realBuffer)
-
-    const fetcher = createFetchComponent()
-    fetcher.fetch = jest.fn().mockResolvedValue({
-      buffer: jest.fn().mockResolvedValueOnce(failBuffer).mockResolvedValueOnce(realBuffer)
-    })
-    const client = buildClient(URL, fetcher)
-
-    await client.downloadContent(fileHash, { retryDelay: 20 })
-
-    expect(fetcher.fetch).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        headers: { 'X-Requested-With': getCurrentVersion() }
-      })
-    )
-  })
-
   it('When checking if content is available, then the result is as expected', async () => {
     const [hash1, hash2] = ['hash1', 'hash2']
     const requestResult: AvailableContentResult = [
@@ -285,29 +209,6 @@ describe('ContentClient', () => {
 
     await expect(client.isContentAvailable([])).rejects.toEqual(`You must set at least one cid.`)
     expect(fetcher.fetch).not.toHaveBeenCalled()
-  })
-
-  it('When checking if content is available, then the X-Requested-With default header is included', async () => {
-    const [hash1, hash2] = ['hash1', 'hash2']
-    const requestResult: AvailableContentResult = [
-      { cid: hash1, available: true },
-      { cid: hash2, available: false }
-    ]
-
-    const fetcher = createFetchComponent()
-    fetcher.fetch = jest.fn().mockResolvedValue({
-      json: jest.fn().mockReturnValue(requestResult)
-    })
-    const client = buildClient(URL, fetcher)
-
-    await client.isContentAvailable([hash1, hash2])
-
-    expect(fetcher.fetch).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        headers: { 'X-Requested-With': getCurrentVersion(), 'Content-Type': 'application/json' }
-      })
-    )
   })
 
   function someEntity(): Entity {


### PR DESCRIPTION
We need to include the x-requested-by header as allowed header in the server, but I'm not quite sure why is not included right now:

```
Access to XMLHttpRequest at 'https://peer-ap1.decentraland.zone/lambdas/profiles' from origin 'https://marketplace-qka1jpxj2-decentraland1.vercel.app/' has been blocked by CORS policy: Request header field x-requested-with is not allowed by Access-Control-Allow-Headers in preflight response.
```