### PR TITLE
fix: query-params handling at fetcher

### DIFF
--- a/src/client/utils/fetcher.ts
+++ b/src/client/utils/fetcher.ts
@@ -15,7 +15,7 @@ export type CustomClient<T> = (baseUrl: string, fetch: IFetchComponent) => Promi
 export const useCustomClient = <T>({ url, method, params, data, headers }: Context): CustomClient<T> => {
   const relPath = url.substring('/lambdas'.length + 1)
   return async function (baseUrl: string, fetch: IFetchComponent): Promise<T> {
-    const response = await fetch.fetch(`${baseUrl}/${relPath}` + new URLSearchParams(params), {
+    const response = await fetch.fetch(`${baseUrl}/${relPath}?` + new URLSearchParams(params), {
       method,
       headers,
       ...(data ? { body: JSON.stringify(data) } : {})


### PR DESCRIPTION
# Description

This PR introduces a fix on how requests to Catalyst are formatted when including a query parameter.

Current format example:
`https://<HOST>/lambdas/users/<ADDRESS>/namespageSize=1`

Expected format example:
`https://<HOST>/lambdas/users/<ADDRESS>/names?pageSize=1`