### PR TITLE
feat!: build deployments with web-standard FormData

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,11 @@
     "@dcl/schemas": "^23.0.0",
     "@well-known-components/fetch-component": "^2.0.0",
     "cookie": "^0.5.0",
-    "cross-fetch": "^3.1.5",
-    "form-data": "^4.0.0"
+    "cross-fetch": "^3.1.5"
   },
   "devDependencies": {
     "@dcl/catalyst-api-specs": "^3.8.0",
     "@dcl/eslint-config": "^1.1.9",
-    "@types/form-data": "^2.5.0",
     "@well-known-components/env-config-provider": "^1.1.1",
     "@well-known-components/interfaces": "^1.4.0",
     "@well-known-components/logger": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "description": "A client to query and perform changes on Decentraland's catalyst servers",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "prebuild": "rm -rf dist && yarn generate:snapshots",
     "generate:snapshots": "ts-node -T scripts/generate-snapshots.ts",
@@ -31,11 +34,10 @@
   "dependencies": {
     "@dcl/catalyst-contracts": "^4.4.0",
     "@dcl/crypto": "^3.4.0",
+    "@dcl/fetch-component": "^1.0.1",
     "@dcl/hashing": "^3.0.0",
     "@dcl/schemas": "^23.0.0",
-    "@well-known-components/fetch-component": "^2.0.0",
-    "cookie": "^0.5.0",
-    "cross-fetch": "^3.1.5"
+    "cookie": "^0.5.0"
   },
   "devDependencies": {
     "@dcl/catalyst-api-specs": "^3.8.0",

--- a/scripts/generate-snapshots.ts
+++ b/scripts/generate-snapshots.ts
@@ -12,7 +12,7 @@ import {
   NameDenylistContract,
   PoiContract
 } from '@dcl/catalyst-contracts'
-import { createFetchComponent } from '@well-known-components/fetch-component'
+import { createFetchComponent } from '@dcl/fetch-component'
 import RequestManager, { bytesToHex, ContractFactory, HTTPProvider } from 'eth-connect'
 import fs from 'fs'
 

--- a/src/client/ContentClient.ts
+++ b/src/client/ContentClient.ts
@@ -1,16 +1,8 @@
 import { hashV0, hashV1 } from '@dcl/hashing'
 import { Entity } from '@dcl/schemas'
-import FormData from 'form-data'
 import { ClientOptions, DeploymentData, IFetchComponent, ParallelConfig, RequestOptions } from './types'
-import { addModelToFormData, isNode, mergeRequestOptions, sanitizeUrl, splitAndFetch } from './utils/Helper'
+import { addModelToFormData, mergeRequestOptions, sanitizeUrl, splitAndFetch } from './utils/Helper'
 import { retry } from './utils/retry'
-
-function arrayBufferFrom(value: Buffer | Uint8Array) {
-  if (value.buffer) {
-    return value.buffer
-  }
-  return value
-}
 
 export type AvailableContentResult = {
   cid: string
@@ -177,9 +169,9 @@ export function createContentClient(options: ClientOptions): ContentClient {
     deployData: DeploymentData,
     options?: RequestOptions
   ): Promise<FormData> {
-    // Check if we are running in node or browser
-    const areWeRunningInNode = isNode()
-
+    // Use the web-standard FormData/Blob (global in browsers and Node >= 18). When this form is
+    // used as a request body, native fetch (and node-fetch v3) set the multipart Content-Type with
+    // the boundary automatically, so the deployment works without a node-fetch-specific fetcher.
     const form = new FormData()
     form.append('entityId', deployData.entityId)
     addModelToFormData(deployData.authChain, form, 'authChain')
@@ -187,17 +179,7 @@ export function createContentClient(options: ClientOptions): ContentClient {
     const alreadyUploadedHashes = await hashesAlreadyOnServer(Array.from(deployData.files.keys()), options)
     for (const [fileHash, file] of deployData.files) {
       if (!alreadyUploadedHashes.has(fileHash) || fileHash === deployData.entityId) {
-        if (areWeRunningInNode) {
-          // Node
-          form.append(
-            fileHash,
-            Buffer.isBuffer(file) ? file : Buffer.from(arrayBufferFrom(file) as ArrayBuffer),
-            fileHash
-          )
-        } else {
-          // Browser
-          form.append(fileHash, new Blob([arrayBufferFrom(file) as ArrayBuffer]), fileHash)
-        }
+        form.append(fileHash, new Blob([file]), fileHash)
       }
     }
 

--- a/src/client/ContentClient.ts
+++ b/src/client/ContentClient.ts
@@ -16,7 +16,7 @@ export type ContentClient = {
   fetchEntitiesByPointers(pointers: string[], options?: RequestOptions): Promise<Entity[]>
   fetchEntitiesByIds(ids: string[], options?: RequestOptions & { parallel?: ParallelConfig }): Promise<Entity[]>
   fetchEntityById(id: string, options?: RequestOptions & { parallel?: ParallelConfig }): Promise<Entity>
-  downloadContent(contentHash: string, options?: RequestOptions & { avoidChecks?: boolean }): Promise<Buffer>
+  downloadContent(contentHash: string, options?: RequestOptions & { avoidChecks?: boolean }): Promise<Uint8Array>
 
   isContentAvailable(cids: string[], options?: RequestOptions): Promise<AvailableContentResult>
 
@@ -43,7 +43,7 @@ export async function downloadContent(
   baseUrl: string,
   contentHash: string,
   options?: Partial<RequestOptions> & { avoidChecks?: boolean }
-): Promise<Buffer> {
+): Promise<Uint8Array> {
   const { attempts = 3, retryDelay = 500 } = options ? options : {}
   const timeout = options?.timeout ? { timeout: options.timeout } : {}
 
@@ -51,7 +51,7 @@ export async function downloadContent(
     `fetch file with hash ${contentHash} from ${baseUrl}`,
     async () => {
       const response = await fetcher.fetch(`${baseUrl}/${contentHash}`, timeout)
-      const content = Buffer.from(await response.arrayBuffer())
+      const content = new Uint8Array(await response.arrayBuffer())
       if (!options?.avoidChecks) {
         const downloadedHash = contentHash.startsWith('Qm') ? await hashV0(content) : await hashV1(content)
 

--- a/src/client/utils/Helper.ts
+++ b/src/client/utils/Helper.ts
@@ -1,5 +1,4 @@
 import { createFetchComponent } from '@well-known-components/fetch-component'
-import type FormData from 'form-data'
 import { IFetchComponent, RequestOptions } from '../types'
 import { commit, version } from './../../package.json'
 

--- a/src/client/utils/Helper.ts
+++ b/src/client/utils/Helper.ts
@@ -1,4 +1,4 @@
-import { createFetchComponent } from '@well-known-components/fetch-component'
+import { createFetchComponent } from '@dcl/fetch-component'
 import { IFetchComponent, RequestOptions } from '../types'
 import { commit, version } from './../../package.json'
 
@@ -196,10 +196,6 @@ export function convertFiltersToQueryParams(filters?: Record<string, any>): Map<
     })
     .filter(([_, values]) => values.length > 0)
   return new Map(entries)
-}
-
-export function isNode() {
-  return Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]'
 }
 
 export function mergeRequestOptions(target: RequestOptions, source?: RequestOptions): RequestOptions {

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -131,8 +131,8 @@ describe('ContentClient', () => {
 
     const result = await client.downloadContent(fileHash, { retryDelay: 20 })
 
-    // Assert that the correct buffer is returned, and that there was a retry attempt
-    expect(result).toEqual(realBuffer)
+    // Assert that the correct content is returned, and that there was a retry attempt
+    expect(result).toEqual(new Uint8Array(realBuffer))
     expect(fetcher.fetch).toHaveBeenCalledTimes(2)
   })
 
@@ -149,7 +149,7 @@ describe('ContentClient', () => {
 
     const client = buildClient(URL, fetcher)
     const result = await client.downloadContent(fileHash, { retryDelay: 20, avoidChecks: true })
-    expect(result).toEqual(failBuffer)
+    expect(result).toEqual(new Uint8Array(failBuffer))
     expect(fetcher.fetch).toHaveBeenCalledTimes(1)
   })
 

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -1,6 +1,6 @@
 import { hashV0 } from '@dcl/hashing'
 import { Entity, EntityType } from '@dcl/schemas'
-import { createFetchComponent } from '@well-known-components/fetch-component'
+import { createFetchComponent } from '@dcl/fetch-component'
 import { AvailableContentResult, ContentClient, createContentClient, IFetchComponent } from '../src'
 
 describe('ContentClient', () => {

--- a/test/ContentClient.spec.ts
+++ b/test/ContentClient.spec.ts
@@ -18,42 +18,19 @@ describe('ContentClient', () => {
 
       const form = await client.buildEntityFormDataForDeployment({ authChain: [], entityId: 'QmENTITY', files })
 
-      const formData = form.getBuffer().toString().replace(/\s*$/gm, '')
+      // The deployment form is now a web-standard FormData: plain fields are strings and files are
+      // File/Blob entries keyed (and named) by their hash.
+      expect(form.get('entityId')).toBe('QmENTITY')
 
-      expect(formData).toContain(
-        `
-        | Content-Disposition: form-data; name="QmA"; filename="QmA"
-        | Content-Type: application/octet-stream
-        |
-        |
-        | opq
-        `
-          .replace(/^(\s*\|\s)*/gm, '') // scala, I miss you buddy...
-          .trim()
-      )
+      const qmA = form.get('QmA') as File
+      expect(qmA).toBeInstanceOf(Blob)
+      expect(qmA.name).toBe('QmA')
+      expect(await qmA.text()).toBe('opq')
 
-      expect(formData).toContain(
-        `
-        | Content-Disposition: form-data; name="entityId"
-        |
-        |
-        | QmENTITY
-        `
-          .replace(/^(\s*\|\s)*/gm, '') // scala, I miss you buddy...
-          .trim()
-      )
-
-      expect(formData).toContain(
-        `
-        | Content-Disposition: form-data; name="QmB"; filename="QmB"
-        | Content-Type: application/octet-stream
-        |
-        |
-        | asd
-        `
-          .replace(/^(\s*\|\s)*/gm, '') // scala, I miss you buddy...
-          .trim()
-      )
+      const qmB = form.get('QmB') as File
+      expect(qmB).toBeInstanceOf(Blob)
+      expect(qmB.name).toBe('QmB')
+      expect(await qmB.text()).toBe('asd')
     })
   })
 

--- a/test/unit/Helper.spec.ts
+++ b/test/unit/Helper.spec.ts
@@ -1,4 +1,4 @@
-import { createFetchComponent } from '@well-known-components/fetch-component'
+import { createFetchComponent } from '@dcl/fetch-component'
 import {
   MAX_URL_LENGTH,
   convertFiltersToQueryParams,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
       "node"
     ],
     "sourceMap": true,
+    "skipLibCheck": true,
     "moduleResolution": "node16",
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1322,13 +1322,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/form-data@^2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.5.0.tgz#5025f7433016f923348434c40006d9a797c1b0e8"
-  integrity sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==
-  dependencies:
-    form-data "*"
-
 "@types/graceful-fs@^4.1.3":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
@@ -2648,15 +2641,6 @@ for-each@^0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
-
-form-data@*, form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 form-data@^3.0.0:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -360,6 +360,13 @@
   resolved "https://registry.yarnpkg.com/@dcl/catalyst-contracts/-/catalyst-contracts-4.4.0.tgz#a36a599f5e0c4b15e653650f74fcaa3da1f525ec"
   integrity sha512-jA4LU/f0VQI4epwctUZFIxnvnXBSsWGdoDibuV1kIW1nnooqRmCKdN2bbQKYWhWKtwjQfUHvbUKLzA+dD2a1gw==
 
+"@dcl/core-commons@0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@dcl/core-commons/-/core-commons-0.10.0.tgz#cbdcc810f55a1a708b9250ab566b951f312841e2"
+  integrity sha512-lcCgnwxkq/MoTbU59wKnspmVaQyEIP8SRRDUCd3Werrwj+nsH6T7xGuVo17cLVEd8D/Hi3NLFtBiq+N7kZAt/A==
+  dependencies:
+    "@well-known-components/interfaces" "^1.5.2"
+
 "@dcl/crypto@^3.4.0":
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/@dcl/crypto/-/crypto-3.4.5.tgz#95ca2beab46fa3494b4d38f009bf0d49c87ba235"
@@ -385,6 +392,13 @@
     eslint-plugin-import "npm:eslint-plugin-i@^2.27.5-3"
     eslint-plugin-prettier "^4.2.1"
     prettier "^2.8.8"
+
+"@dcl/fetch-component@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@dcl/fetch-component/-/fetch-component-1.0.1.tgz#7cfb6d2d2bc6b40c9eca238be212626d511284c4"
+  integrity sha512-OgkOeBtIfxuQ96caFnE+JDORiQEBKajF3DpB7T5ZcoVkbnKGnJ1fmk4eOklzA+Eqt2LOAKsXfKa1RqR9bPwUlg==
+  dependencies:
+    "@dcl/core-commons" "0.10.0"
 
 "@dcl/hashing@^3.0.0":
   version "3.0.4"
@@ -1511,18 +1525,19 @@
   dependencies:
     dotenv "^16.0.1"
 
-"@well-known-components/fetch-component@^2.0.0":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@well-known-components/fetch-component/-/fetch-component-2.0.2.tgz#02260611f9d05551efe825c4358cbc628a71c4c0"
-  integrity sha512-LdY+6n9kuyACg3fcU4qMrNhLZuG7eqPxLSqzDgQyoHKeNjlzggoUqTVJKtIyi6vjPs8pSQ/Fx1xdLuBhOKCgww==
-  dependencies:
-    "@well-known-components/interfaces" "^1.4.1"
-    cross-fetch "^3.1.5"
-
-"@well-known-components/interfaces@^1.4.0", "@well-known-components/interfaces@^1.4.1":
+"@well-known-components/interfaces@^1.4.0":
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.4.2.tgz#e37eb296280abfcab14f0608b3bdfc84d5a21929"
   integrity sha512-1tkr/OhZ4UmnQiST2svKznEiJ86crV2S+AIhokhowR4MexAKWgYlmZpoP6VIcgDVPf7nu8hOtIPMQaCZ+COC0A==
+  dependencies:
+    "@types/node" "^20.3.1"
+    "@types/node-fetch" "^2.5.12"
+    typed-url-params "^1.0.1"
+
+"@well-known-components/interfaces@^1.5.2":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/@well-known-components/interfaces/-/interfaces-1.5.2.tgz#ef7001a19d410459e65b216dd948d15be19e4efa"
+  integrity sha512-TzKQblOci2Azczk1DZ4JL5aJW7hwq7kHrFMO4lCRMmW51bA71BtiZlq0WP72Dln067xTSoHQAU4WHCFJlGYvEQ==
   dependencies:
     "@types/node" "^20.3.1"
     "@types/node-fetch" "^2.5.12"
@@ -2003,13 +2018,6 @@ create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
-
-cross-fetch@^3.1.5:
-  version "3.1.6"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
-  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
-  dependencies:
-    node-fetch "^2.6.11"
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -3832,7 +3840,7 @@ node-fetch-h2@^2.3.0:
   dependencies:
     http2-client "^1.2.5"
 
-node-fetch@2.x, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.11, node-fetch@^2.6.7:
+node-fetch@2.x, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==


### PR DESCRIPTION
## What

Makes the client **isomorphic on native fetch** — it works in both Node (≥ 18) and the browser, with no node-fetch / Node-only APIs in the request/response paths.

### Deployments use web-standard `FormData`
`deploy()` builds the multipart body with the web-standard `FormData` + `Blob` (global in browsers and Node ≥ 18) instead of the Node [`form-data`](https://www.npmjs.com/package/form-data) package. Files are appended as `Blob`s for both node and browser, so the old `isNode()` branch is gone.

`form-data` produced a stream whose `multipart/...; boundary=` Content-Type only got set when the request went through node-fetch — so `deploy()` couldn't be used with a native-fetch fetcher (it sent `text/plain` and dropped the body). With web `FormData`, **native fetch** (and node-fetch v3 / browsers) set the multipart Content-Type automatically.

**Proof** (web FormData → native `fetch()` → busboy parse):
```
content-type: multipart/form-data; boundary=----formdata-undici-...   ← native fetch set it
field entityId: QmENTITY        file QmA: { filename: "QmA", content: "opq" }
authChain[0][type]: SIGNER      file QmB: { filename: "QmB", content: "asd" }
```

### Downloads return `Uint8Array`
`downloadContent()` previously returned a Node `Buffer` (`Buffer.from(...)`), which doesn't exist in the browser. It now returns a web-standard `Uint8Array` — the last Node-only API in `src`. The internal hash check (`hashV0`/`hashV1`) already accepts `Uint8Array`.

### Fully native + cleanup
- **Default fetcher** now uses `@dcl/fetch-component` (native, same retry/timeout behaviour) instead of `@well-known-components/fetch-component` (which was node-fetch v2 via cross-fetch).
- **Dropped dependencies**: `form-data`, `@types/form-data`, `@well-known-components/fetch-component`, `cross-fetch`.
- **`engines.node` set to `>=18`** (the client now relies on global `fetch`/`FormData`/`Blob`).
- **Removed** the dead, non-exported `isNode()` helper.
- **`skipLibCheck`** enabled (the `@dcl/core-commons` declarations pulled in via `@dcl/fetch-component` reference `jest` types in their published mocks).

## Breaking changes

1. **`deploy()`** requires the injected fetcher to support **web-standard `FormData` request bodies** — native fetch, node-fetch v3, or a browser `fetch`. Fetchers built on **node-fetch v2** no longer serialize the deployment body correctly.
2. **`downloadContent()`** now resolves to **`Uint8Array`** instead of `Buffer`. `Buffer` is a `Uint8Array` subclass so byte access is unchanged, but consumers using `Buffer`-only methods (e.g. `toString('hex')`) must wrap the result with `Buffer.from(...)`.

## Tests

- Rewrote the `buildEntityFormDataForDeployment` unit test to assert via the web `FormData` API (`form.get()`, `File.name`, `Blob.text()`) instead of node form-data's `.getBuffer()`.
- Updated `downloadContent` assertions to compare `Uint8Array`.
- Full build (`prebuild` snapshots + orval + `tsc`) ✓, suite **55 passed / 4 suites**, `tsc --noEmit` ✓, eslint ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)