### PR TITLE
fix: throw on non-ok lambdas responses instead of returning malformed data

### DIFF
--- a/src/client/utils/fetcher.ts
+++ b/src/client/utils/fetcher.ts
@@ -1,4 +1,5 @@
 import { IFetchComponent } from '../types'
+import { readJsonOrThrow } from './response'
 
 type Context = {
   url: string
@@ -21,7 +22,7 @@ export const useCustomClient = <T>({ url, method, params, data, headers }: Conte
       ...(data ? { body: JSON.stringify(data) } : {})
     })
 
-    return response.json()
+    return readJsonOrThrow<T>(response)
   }
 }
 

--- a/src/client/utils/response.ts
+++ b/src/client/utils/response.ts
@@ -1,0 +1,22 @@
+import { FetchResponse } from '../types'
+
+/**
+ * Reads a fetch response as JSON while ALWAYS releasing the underlying body.
+ *
+ * With the native (undici) `fetch`, the keep-alive socket backing a response stays pinned until
+ * the body is read or cancelled — so discarding a response without consuming its body leaks the
+ * connection (and buffers received bytes) until GC. On a non-ok response this drains the body via
+ * `text()` and throws an error including the status and body; on ok it parses and returns the JSON
+ * (which consumes the body).
+ */
+export async function readJsonOrThrow<T>(response: FetchResponse): Promise<T> {
+  if (!response.ok) {
+    // Reading the body releases the socket and makes the thrown error useful. Guarded so a
+    // non-conforming fetcher (a Response without text()) still yields a clean status error
+    // rather than a "text is not a function" TypeError.
+    const body = typeof response.text === 'function' ? await response.text().catch(() => '') : ''
+    throw new Error(`Catalyst responded with status ${response.status}${body ? `: ${body}` : ''}`)
+  }
+
+  return (await response.json()) as T
+}

--- a/test/unit/response.spec.ts
+++ b/test/unit/response.spec.ts
@@ -1,0 +1,50 @@
+import { readJsonOrThrow } from '../../src/client/utils/response'
+import { FetchResponse } from '../../src/client/types'
+
+function mockResponse(overrides: { ok: boolean; status: number; json?: jest.Mock; text?: jest.Mock }): FetchResponse {
+  return {
+    json: overrides.json ?? jest.fn(),
+    text: overrides.text ?? jest.fn(),
+    arrayBuffer: jest.fn(),
+    ok: overrides.ok,
+    status: overrides.status
+  } as unknown as FetchResponse
+}
+
+describe('readJsonOrThrow', () => {
+  it('When the response is ok, then it parses and returns the JSON without reading the body as text', async () => {
+    const json = jest.fn().mockResolvedValue({ a: 1 })
+    const text = jest.fn()
+
+    const result = await readJsonOrThrow<{ a: number }>(mockResponse({ ok: true, status: 200, json, text }))
+
+    expect(result).toEqual({ a: 1 })
+    expect(text).not.toHaveBeenCalled()
+  })
+
+  it('When the response is not ok, then it drains the body via text() and throws with the status and body', async () => {
+    const json = jest.fn()
+    const text = jest.fn().mockResolvedValue('upstream boom')
+
+    await expect(readJsonOrThrow(mockResponse({ ok: false, status: 503, json, text }))).rejects.toThrow(
+      'Catalyst responded with status 503: upstream boom'
+    )
+    expect(text).toHaveBeenCalledTimes(1) // body drained so the keep-alive socket is released
+    expect(json).not.toHaveBeenCalled()
+  })
+
+  it('When the error body cannot be read, then it still throws with the status', async () => {
+    const text = jest.fn().mockRejectedValue(new Error('stream error'))
+
+    await expect(readJsonOrThrow(mockResponse({ ok: false, status: 500, json: jest.fn(), text }))).rejects.toThrow(
+      'Catalyst responded with status 500'
+    )
+  })
+
+  it('When a non-conforming response has no text(), then it still throws with the status', async () => {
+    // A fetcher whose Response omits text() must not turn the error into a "text is not a function" crash.
+    const response = { ok: false, status: 502, json: jest.fn() } as unknown as FetchResponse
+
+    await expect(readJsonOrThrow(response)).rejects.toThrow('Catalyst responded with status 502')
+  })
+})


### PR DESCRIPTION
## Problem
`useCustomClient` (`src/client/utils/fetcher.ts`) — the fetcher behind every generated `LambdasClient` method (e.g. `getNames`) — did `return response.json()` with **no status check**. On a non-ok response (4xx/5xx) it parsed the error body and returned it **as if it were the success type**, so callers got malformed data that failed confusingly downstream (e.g. `.elements` undefined → a later `.map` throws) instead of a clear error — and the error body/status was never surfaced.

## Fix
Add `readJsonOrThrow` (`src/client/utils/response.ts`):
- **non-ok** → read the body via `text()` (which also releases the underlying keep-alive socket under native/undici fetch) and **throw** an error including the status and body;
- **ok** → parse and return the JSON.

Route `useCustomClient` through it. Now `getNames` and every other lambdas method reject with a clear `Catalyst responded with status N: <body>` on failure instead of returning garbage. Consumers that wrap these in retry/try-catch (e.g. social-service's `getOwnedNames`) get a real error to log/retry.

## Scope / follow-up
Deliberately narrow. The same "parse without checking `.ok`" pattern exists in `Helper.ts`'s `splitAndFetch` (content path) and `splitAndFetchPaginated` — the latter also has a **missing `await`** on `.json()` (its `response` is a Promise, so it silently returns `[]`). Those touch the ContentClient surface and its tests, so I left them for a focused follow-up rather than widen this PR.

## Testing
`yarn build` (orval + tsc) ✓, `eslint` ✓, `yarn jest` (non-E2E) **4 suites / 57 tests** ✓ — adds `test/unit/response.spec.ts` covering ok (returns JSON, doesn't read text), non-ok (drains body + throws with status/body), and an unreadable error body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)